### PR TITLE
fix: Add the download attribute in the FileViewer

### DIFF
--- a/packages/frontend/src/components/file-viewer/file-viewer.tsx
+++ b/packages/frontend/src/components/file-viewer/file-viewer.tsx
@@ -297,7 +297,7 @@ export const FileViewer = ({
 
           {canDownload && (
             <Tooltip placement="bottom" label={downloadTooltip} aria-label={downloadTooltip}>
-              <Link href={downloadUrl} target="_blank">
+              <Link href={downloadUrl} download>
                 <IconButton aria-label={downloadTooltip} size="sm" icon={iconFactoryAs('download')} />
               </Link>
             </Tooltip>


### PR DESCRIPTION
Fixes issues with certain file types that the browser wants to display rather than download as a file.