### PR TITLE
refactor: Remove deprecated tag code

### DIFF
--- a/packages/backend/src/lib/backends/github.sync.ts
+++ b/packages/backend/src/lib/backends/github.sync.ts
@@ -211,12 +211,6 @@ export const githubRepositorySync = async (
     // Format all tags into lowercase, then dedupe using a Set
     insight.tags = [...new Set(insight.tags.map((tag) => tag.toLowerCase()))];
 
-    // Check for special tags
-    // DEPRECATED--will be removed shortly
-    if (insight.tags.includes('iex-template')) {
-      insight.itemType = ItemType.TEMPLATE;
-    }
-
     await syncFiles(gitInstance, insight, previousInsight);
 
     // Determine thumbnail

--- a/packages/frontend/src/pages/insight-editor/insight-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-editor.tsx
@@ -240,10 +240,6 @@ export const InsightEditor = memo(
         const { id, ...template }: Insight = data.template;
 
         if (template) {
-          template.tags = template.tags.filter((tag) => {
-            return tag === 'iex-template' ? false : true;
-          });
-
           // Retain name/description/itemType when changing templates
           const { name, description, itemType } = form.getValues();
           const newReadme = {


### PR DESCRIPTION
Removed lines were previously used to detect templates via tags, which has since been replaced by item types.