### PR TITLE
fix: Ensure `updatedAt` is current when publishing changes

### DIFF
--- a/packages/backend/src/lib/backends/github.sync.ts
+++ b/packages/backend/src/lib/backends/github.sync.ts
@@ -184,6 +184,13 @@ export const githubRepositorySync = async (
     // Load insight details from GitHub metadata
     const insight = await getInsightFromRepository(item.owner, item.repo);
 
+    if (item.updated) {
+      // If this flag is set, it means an update was just pushed.
+      // Sometimes, the GitHub API hasn't recognized the update yet, so we
+      // need to manually update the updatedAt field to now.
+      insight.updatedAt = insight.syncedAt;
+    }
+
     // Short-circuit if the repository is archived
     if (insight.repository.isArchived) {
       logger.warn(`[GITHUB_SYNC] This repository is archived; stopping sync`);

--- a/packages/backend/src/models/tasks.ts
+++ b/packages/backend/src/models/tasks.ts
@@ -27,4 +27,14 @@ export interface InsightSyncTask {
    * visible after indexing.
    */
   refresh?: boolean;
+
+  /**
+   * Optional flag that indicates the repository was just updated.
+   *
+   * If true, the sync task will use the current time as the `updatedAt` field,
+   * rather than the repository's `updatedAt` field value.
+   *
+   * This avoids any potential sychronization issues with the repository.
+   */
+  updated?: boolean;
 }

--- a/packages/backend/src/resolvers/insight.resolver.ts
+++ b/packages/backend/src/resolvers/insight.resolver.ts
@@ -362,7 +362,8 @@ export class InsightResolver {
         owner: repository.owner.login,
         repo: repository.externalName,
         repositoryType: RepositoryType.GITHUB,
-        refresh: true
+        refresh: true,
+        updated: true
       })) as Insight;
 
       // Log activity


### PR DESCRIPTION
Occasionally the GitHub API will return an old value for `updatedAt` if we sync too quickly after pushing a change.  This change overrides that value whenever we sync after publishing, and uses the current timestamp rather than the GitHub API value.