### PR TITLE
refactor: Prefer consistent type imports

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -24,6 +24,11 @@ settings:
       moduleDirectory: ['node_modules', 'src/']
 rules:
   no-console: ['error']
+  '@typescript-eslint/consistent-type-imports':
+    - error
+    -
+      prefer: type-imports
+      disallowTypeAnnotations: false
   '@typescript-eslint/no-explicit-any': off
   '@typescript-eslint/no-non-null-assertion': off
   import/newline-after-import: off

--- a/packages/backend/.eslintrc.yml
+++ b/packages/backend/.eslintrc.yml
@@ -7,6 +7,7 @@ settings:
         - tsconfig.json
 rules:
   no-console: ['error']
+  '@typescript-eslint/consistent-type-imports': off
   '@typescript-eslint/no-explicit-any': off
   '@typescript-eslint/no-non-null-assertion': off
   '@typescript-eslint/member-ordering':  [

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -29,7 +29,7 @@ for (const packageName of packages) {
 }
 
 import './environment';
-import { Server } from 'http';
+import type { Server } from 'http';
 
 import { bootstrap, defaultKnex } from './lib/db';
 import { deployMappings } from './lib/elasticsearch';

--- a/packages/backend/src/lib/storage.ts
+++ b/packages/backend/src/lib/storage.ts
@@ -15,9 +15,10 @@
  */
 
 import logger from '@iex/shared/logger';
-import { AWSError, Request, S3 } from 'aws-sdk';
-import { HeadObjectOutput } from 'aws-sdk/clients/s3';
-import { ReadStream } from 'fs-extra';
+import { S3 } from 'aws-sdk';
+import type { AWSError, Request } from 'aws-sdk';
+import type { HeadObjectOutput } from 'aws-sdk/clients/s3';
+import type { ReadStream } from 'fs-extra';
 
 const defaultOptions: S3.Types.ClientConfiguration = {
   region: process.env.S3_REGION,

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -20,7 +20,8 @@ import path from 'path';
 
 import logger from '@iex/shared/logger';
 import compression from 'compression';
-import express, { NextFunction, Request, Response } from 'express';
+import express from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import morgan from 'morgan';
 

--- a/packages/convertbot/src/controllers/convert.v1.ts
+++ b/packages/convertbot/src/controllers/convert.v1.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Request, Response } from 'express';
+import type { Request, Response } from 'express';
 
 /**
  * GET /

--- a/packages/convertbot/src/controllers/home.v1.ts
+++ b/packages/convertbot/src/controllers/home.v1.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Request, Response } from 'express';
+import type { Request, Response } from 'express';
 
 /**
  * GET /

--- a/packages/convertbot/src/conversions.ts
+++ b/packages/convertbot/src/conversions.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Convertbot } from './lib/convertbot';
+import type { Convertbot } from './lib/convertbot';
 import { exec } from './lib/exec';
 
 export const registerConversionMappings = (convertbot: Convertbot): void => {

--- a/packages/convertbot/src/index.ts
+++ b/packages/convertbot/src/index.ts
@@ -29,7 +29,7 @@ for (const packageName of packages) {
 }
 
 import './environment';
-import { Server } from 'http';
+import type { Server } from 'http';
 
 import app from './server';
 import logger from '@iex/shared/logger';

--- a/packages/convertbot/src/lib/convertbot.ts
+++ b/packages/convertbot/src/lib/convertbot.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { ConvertibleFile, ConvertRequest } from '@iex/models/convertbot/convert-request';
+import type { ConvertibleFile, ConvertRequest } from '@iex/models/convertbot/convert-request';
 import { MessageQueue } from '@iex/mq/message-queue';
 import logger from '@iex/shared/logger';
 import { Storage } from '@iex/shared/storage';

--- a/packages/convertbot/src/server.ts
+++ b/packages/convertbot/src/server.ts
@@ -18,7 +18,8 @@ import 'express-async-errors';
 
 import logger from '@iex/shared/logger';
 import compression from 'compression';
-import express, { NextFunction, Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
+import express from 'express';
 import { StatusCodes } from 'http-status-codes';
 import morgan from 'morgan';
 

--- a/packages/models/src/indexed/indexed-insight-file.ts
+++ b/packages/models/src/indexed/indexed-insight-file.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { InsightFileAction } from '../insight-file-action';
+import type { InsightFileAction } from '../insight-file-action';
 
 export interface IndexedInsightFileConversion {
   mimeType: string;

--- a/packages/models/src/indexed/indexed-insight-user.ts
+++ b/packages/models/src/indexed/indexed-insight-user.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { IndexedRepositoryPerson } from './indexed-repository-person';
+import type { IndexedRepositoryPerson } from './indexed-repository-person';
 
 export interface IndexedInsightUser {
   userId?: number;

--- a/packages/models/src/indexed/indexed-insight.ts
+++ b/packages/models/src/indexed/indexed-insight.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { ItemType } from '../item-type';
+import type { ItemType } from '../item-type';
 
-import { IndexedInsightCreation } from './indexed-insight-creation';
-import { IndexedInsightFile } from './indexed-insight-file';
-import { IndexedInsightMetadata } from './indexed-insight-metadata';
-import { IndexedInsightReadme } from './indexed-insight-readme';
-import { IndexedInsightUser } from './indexed-insight-user';
-import { IndexedRepository } from './indexed-repository';
+import type { IndexedInsightCreation } from './indexed-insight-creation';
+import type { IndexedInsightFile } from './indexed-insight-file';
+import type { IndexedInsightMetadata } from './indexed-insight-metadata';
+import type { IndexedInsightReadme } from './indexed-insight-readme';
+import type { IndexedInsightUser } from './indexed-insight-user';
+import type { IndexedRepository } from './indexed-repository';
 
 /**
  * Model for an indexed Insight, rather than the API model.

--- a/packages/models/src/indexed/indexed-repository-person.ts
+++ b/packages/models/src/indexed/indexed-repository-person.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { PersonType } from '../person-type';
-import { RepositoryPermission } from '../repository-permission';
+import type { PersonType } from '../person-type';
+import type { RepositoryPermission } from '../repository-permission';
 
 export interface IndexedRepositoryPerson {
   login: string;

--- a/packages/models/src/indexed/indexed-repository.ts
+++ b/packages/models/src/indexed/indexed-repository.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { RepositoryType } from '../repository-type';
+import type { RepositoryType } from '../repository-type';
 
-import { IndexedRepositoryPerson } from './indexed-repository-person';
+import type { IndexedRepositoryPerson } from './indexed-repository-person';
 
 export interface IndexedRepository {
   externalId: string;

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -19,7 +19,7 @@
  *
  * Documentation: https://github.com/winstonjs/winston
  */
-import { TransformableInfo } from 'logform';
+import type { TransformableInfo } from 'logform';
 import { createLogger, format, transports } from 'winston';
 
 // Init Logger

--- a/packages/shared/src/search.ts
+++ b/packages/shared/src/search.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SearchQuery } from '@iex/models/elasticsearch';
+import type { SearchQuery } from '@iex/models/elasticsearch';
 import isArray from 'lodash/isArray';
 import mergeWith from 'lodash/mergeWith';
 import Parsimmon, { optWhitespace } from 'parsimmon';

--- a/packages/shared/src/storage.ts
+++ b/packages/shared/src/storage.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { Readable } from 'stream';
+import type { Readable } from 'stream';
 
 import { S3 } from 'aws-sdk';
-import { ReadStream } from 'fs-extra';
+import type { ReadStream } from 'fs-extra';
 
 import logger from '@iex/shared/logger';
 

--- a/packages/slackbot/src/app.ts
+++ b/packages/slackbot/src/app.ts
@@ -16,7 +16,8 @@
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import logger from '@iex/shared/logger';
-import { App, LinkUnfurls, LogLevel } from '@slack/bolt';
+import type { LinkUnfurls } from '@slack/bolt';
+import { App, LogLevel } from '@slack/bolt';
 
 import { getUnfurl } from './lib/unfurls';
 

--- a/packages/slackbot/src/lib/iex.ts
+++ b/packages/slackbot/src/lib/iex.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { Client, ClientOptions } from '@elastic/elasticsearch';
-import { SearchBody, SearchResponse } from '@iex/models/elasticsearch';
-import { IndexedInsight } from '@iex/models/indexed/indexed-insight';
+import type { ClientOptions } from '@elastic/elasticsearch';
+import { Client } from '@elastic/elasticsearch';
+import type { SearchBody, SearchResponse } from '@iex/models/elasticsearch';
+import type { IndexedInsight } from '@iex/models/indexed/indexed-insight';
 import logger from '@iex/shared/logger';
 
 const defaultOptions: ClientOptions = {

--- a/packages/slackbot/src/lib/unfurls.ts
+++ b/packages/slackbot/src/lib/unfurls.ts
@@ -15,7 +15,7 @@
  */
 
 import logger from '@iex/shared/logger';
-import { MessageAttachment } from '@slack/bolt';
+import type { MessageAttachment } from '@slack/bolt';
 
 import { getInsight } from './iex';
 

--- a/packages/slackbot/src/server.ts
+++ b/packages/slackbot/src/server.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { Server } from 'http';
+import type { Server } from 'http';
 
 import logger from '@iex/shared/logger';
-import express, { Request, Response } from 'express';
+import type { Request, Response } from 'express';
+import express from 'express';
 import morgan from 'morgan';
 
 // Init express


### PR DESCRIPTION
Added ESLint rule `@typescript-eslint/consistent-type-imports` and fixed all occurrences.

Disabled for `backend` package because TypeGraphQL requires type metadata in order to generate the GraphQL schema correctly.