### PR TITLE
chore(workflow): Split release and publish into separate workflows

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -1,0 +1,75 @@
+name: Publish Docker
+on:
+  release:
+    types:
+      - published
+
+concurrency: release
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish-docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - name: Insights Explorer
+            image: expediagroup/insights-explorer
+            dockerfile: ./Dockerfile
+          - name: Convertbot
+            image: expediagroup/insights-explorer-convertbot
+            dockerfile: ./packages/convertbot/Dockerfile
+          - name: Slackbot
+            image: expediagroup/insights-explorer-slackbot
+            dockerfile: ./packages/slackbot/Dockerfile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Parse release version
+        run: |
+          VERSION=${GITHUB_REF_NAME#v*}
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f2)
+          PATCH=$(echo $VERSION | cut -d. -f3)
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker meta - ${{ matrix.name }}
+        uses: docker/metadata-action@v3
+        id: meta
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ matrix.image }}
+          flavor: |
+            latest=true
+          tags: |
+            type=raw,value=${{ env.VERSION }}
+            type=raw,value=${{ env.MAJOR }}.${{ env.MINOR }}
+            type=raw,value=${{ env.MAJOR }},enable=${{ ! env.MAJOR == 0 }}
+
+      - name: Docker build - ${{ matrix.name }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,6 @@ on:
 concurrency: release
 
 env:
-  REGISTRY: ghcr.io
   GIT_AUTHOR_NAME: eg-oss-ci
   GIT_AUTHOR_EMAIL: oss@expediagroup.com
   GIT_COMMITTER_NAME: eg-oss-ci
@@ -68,65 +67,3 @@ jobs:
             @semantic-release/git@10.0.1
             conventional-changelog-conventionalcommits@4.6.1
 
-  publish-docker:
-    needs: release
-    if: needs.release.outputs.new_release_published == 'true'
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    strategy:
-      matrix:
-        include:
-          - name: Insights Explorer
-            image: expediagroup/insights-explorer
-            dockerfile: ./Dockerfile
-          - name: Convertbot
-            image: expediagroup/insights-explorer-convertbot
-            dockerfile: ./packages/convertbot/Dockerfile
-          - name: Slackbot
-            image: expediagroup/insights-explorer-slackbot
-            dockerfile: ./packages/slackbot/Dockerfile
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          # Use previously created release tag
-          ref: v${{ needs.release.outputs.new_release_version }}
-
-      - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Docker meta - ${{ matrix.name }}
-        uses: docker/metadata-action@v3
-        id: meta
-        with:
-          images: |
-            ${{ env.REGISTRY }}/${{ matrix.image }}
-          flavor: |
-            latest=true
-          tags: |
-            type=raw,value=${{ needs.release.outputs.new_release_version }}
-            type=raw,value=${{ needs.release.outputs.new_release_major_version }}.${{ needs.release.outputs.new_release_minor_version }}
-            type=raw,value=${{ needs.release.outputs.new_release_major_version }},enable=${{ ! needs.release.outputs.new_release_major_version == 0 }}
-
-      - name: Docker build - ${{ matrix.name }}
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
This will help address issues where the release completes but the docker publish fails and we cannot rerun it.