### PR TITLE
fix: Mobile-responsive square & compact Insight cards

### DIFF
--- a/packages/frontend/src/components/insight-connection-card/components/compact-insight-card/compact-insight-card.tsx
+++ b/packages/frontend/src/components/insight-connection-card/components/compact-insight-card/compact-insight-card.tsx
@@ -54,8 +54,8 @@ export const CompactInsightCard = ({ insightEdge, options, ...props }: InsightCo
             {insight.name}
           </Heading>
         </LinkOverlay>
-        <Wrap spacing={0} justify="flex-end">
-          {insight.tags.map((tag) => {
+        <Wrap spacing={0} justify="flex-end" display={{ base: 'none', md: 'flex' }}>
+          {insight.tags.slice(0, 5).map((tag) => {
             return (
               <WrapItem key={tag}>
                 <InsightTag tag={tag} dispatchSearch={options.dispatchSearch ?? true} m="0.125rem" />

--- a/packages/frontend/src/components/insight-connection-card/components/square-insight-card/square-insight-card.tsx
+++ b/packages/frontend/src/components/insight-connection-card/components/square-insight-card/square-insight-card.tsx
@@ -43,15 +43,15 @@ export const SquareInsightCard = ({ insightEdge, options, ...props }: InsightCon
   const insight = insightEdge.node;
 
   return (
-    <LinkBox key={insight.id + '-' + insight.fullName}>
+    <LinkBox key={insight.id + '-' + insight.fullName} alignSelf="stretch">
       <VStack
         as={Card}
         bg={bgColor}
         p="1rem"
-        height={{ base: '16rem', md: '17rem', lg: '18rem', '2xl': '20rem' }}
-        width={{ base: '16rem', md: '17rem', lg: '18rem', '2xl': '20rem' }}
+        width={{ base: 'unset', sm: '16rem', md: '17rem', lg: '18rem', '2xl': '20rem' }}
         align="stretch"
         overflow="hidden"
+        sx={{ aspectRatio: '1' }}
         _hover={{ boxShadow: 'lg' }}
         {...props}
       >

--- a/packages/frontend/src/components/insight-list/components/insight-list-skeleton/insight-list-skeleton.tsx
+++ b/packages/frontend/src/components/insight-list/components/insight-list-skeleton/insight-list-skeleton.tsx
@@ -14,9 +14,32 @@
  * limitations under the License.
  */
 
-import { Skeleton } from '@chakra-ui/react';
+import { Skeleton, Wrap } from '@chakra-ui/react';
 
 export const InsightListSkeleton = ({ count = 3, options }) => {
+  // Special handling for Square
+  if (options.layout === 'square') {
+    return (
+      <Wrap
+        spacing="1rem"
+        direction={{ base: 'column', sm: 'row' }}
+        sx={{
+          '> ul': {
+            flexWrap: { base: 'nowrap', sm: 'wrap' }
+          }
+        }}
+      >
+        {new Array(count * 2).fill(1).map((value, index) => (
+          <Skeleton
+            key={`search-results-skeleton-${index}`}
+            sx={{ aspectRatio: '1' }}
+            width={{ base: 'unset', sm: '16rem', md: '17rem', lg: '18rem', '2xl': '20rem' }}
+          />
+        ))}
+      </Wrap>
+    );
+  }
+
   let layoutProps = {};
   switch (options.layout) {
     case 'square':

--- a/packages/frontend/src/components/insight-list/insight-list.tsx
+++ b/packages/frontend/src/components/insight-list/insight-list.tsx
@@ -28,9 +28,19 @@ const EdgeContainer = ({ edges, options }) => {
   switch (options.layout) {
     case 'square':
       return (
-        <Wrap spacing="1rem" pb="1rem">
+        <Wrap
+          spacing="1rem"
+          pb="1rem"
+          direction={{ base: 'column', sm: 'row' }}
+          sx={{
+            '> ul': {
+              // Disable wrap at small screen sizes
+              flexWrap: { base: 'nowrap', sm: 'wrap' }
+            }
+          }}
+        >
           {edges.map((edge) => (
-            <WrapItem key={edge.node.id}>
+            <WrapItem key={edge.node.id} flexDirection={{ base: 'column', sm: 'row' }}>
               <InsightConnectionCard insightEdge={edge} options={options} />
             </WrapItem>
           ))}


### PR DESCRIPTION
This PR improves the mobile-friendliness of the Search results when using either the compact layout or the square layout.

### Compact Layout

**Before**, tags cluttered each result and the title was truncated to accommodate.
**After**, tags are hidden below `md` breakpoint, and limited to the first 5 days above

<img src="https://user-images.githubusercontent.com/3084806/153643282-4d871887-6383-40b6-948a-3f9e2e837d0c.png" height="600px" /> <img src="https://user-images.githubusercontent.com/3084806/153643436-3fa834a1-a2f5-400e-ab0b-61c236d4b593.png" height="600px"/>

### Square Layout

**Before**, the square boxes scaled down slightly at smaller breakpoints and the wrapping container would turn into a single column if there wasn't room for a 2nd column.  The Insight cards didn't size to fit the column, leaving a lot of extra whitespace.
**After**, below the `sm` breakpoint, it turns into a single column and the Insight cards scale to fit the width of the screen.


<img src="https://user-images.githubusercontent.com/3084806/153645151-c1515dfa-2cce-41a0-bae5-1237ce7d4e40.png" height="600px" /> <img src="https://user-images.githubusercontent.com/3084806/153645194-4cb25620-815e-4912-b9d7-c238a11e3e55.png" height="600px" />
 