### PR TITLE
fix: Update GitHub personal access token validation pattern

### DIFF
--- a/packages/frontend/src/pages/settings-page/components/github-settings/github-settings.tsx
+++ b/packages/frontend/src/pages/settings-page/components/github-settings/github-settings.tsx
@@ -65,7 +65,7 @@ const GitHubPersonalAccessTokenInput = ({ name, defaultValue, form }) => {
           placeholder="GitHub Personal Access Token"
           type={show ? 'text' : 'password'}
           defaultValue={defaultValue}
-          {...register(name, { required: true, maxLength: 40, pattern: /^[A-Za-z0-9]{40}$/ })}
+          {...register(name, { required: true, maxLength: 40, pattern: /^[A-Za-z0-9_]{40}$/ })}
           errorBorderColor="red.300"
           onChange={(e) => (e.target.value = e.target.value.trim())}
         />


### PR DESCRIPTION
GitHub recently updated the format for personal access tokens: 

https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/

This PR updates the front-end validation on the user's GitHub Integration page