### PR TITLE
feat: Add checkbox to enable/disable scroll sync on markdown editor

### DIFF
--- a/packages/frontend/src/components/markdown-container/chakra-ui-renderer.tsx
+++ b/packages/frontend/src/components/markdown-container/chakra-ui-renderer.tsx
@@ -59,10 +59,6 @@ import { XkcdChartRendererAsync } from '../renderers/xkcd-chart-renderer/xkcd-ch
 import './markdown-container.css';
 import 'react-medium-image-zoom/dist/styles.css';
 
-export const getCoreProps = (props): any => {
-  return props['data-sourcepos'] ? { 'data-sourcepos': props['data-sourcepos'] } : {};
-};
-
 const heading = ({ node, level, children, ...props }) => {
   const sizes = ['2xl', 'xl', 'lg', 'md', 'sm', 'xs'];
   const mt = ['2rem', '1.75rem', '1.5rem', '1rem', '1rem', '1rem'];
@@ -80,6 +76,7 @@ const heading = ({ node, level, children, ...props }) => {
       display="flex"
       alignItems="center"
       {...node.properties}
+      {...props}
     >
       {children}
     </Heading>
@@ -88,16 +85,15 @@ const heading = ({ node, level, children, ...props }) => {
 
 const getList = ({ node, ...props }) => {
   const { start, ordered, children, depth } = props;
-  const attrs = getCoreProps(props);
-  if (start !== null && start !== 1 && start !== undefined) {
-    attrs.start = start.toString();
+  if (props.start !== null && props.start !== 1 && props.start !== undefined) {
+    props.start = start.toString();
   }
   let styleType = 'disc';
   if (ordered) styleType = 'decimal';
   if (depth === 1) styleType = 'circle';
 
   return (
-    <List as={ordered ? 'ol' : 'ul'} styleType={styleType} ml={depth === 0 ? '1rem' : 0} pl="1rem" mb="1rem" {...attrs}>
+    <List as={ordered ? 'ol' : 'ul'} styleType={styleType} ml={depth === 0 ? '1rem' : 0} pl="1rem" mb="1rem" {...props}>
       {children}
     </List>
   );
@@ -140,6 +136,7 @@ export const ChakraUIRenderer = (
             fontSize="80%"
             ml="0.5rem"
             color="frost.400"
+            {...props['data-sourcepos']}
           />
         );
       }
@@ -167,7 +164,7 @@ export const ChakraUIRenderer = (
       const language = languageMatch && languageMatch[1];
 
       if (inline) {
-        return <Code {...getCoreProps(props)}>{children}</Code>;
+        return <Code {...props}>{children}</Code>;
       }
 
       if (props.uri) {
@@ -181,6 +178,7 @@ export const ChakraUIRenderer = (
             copyButton={true}
             defaultIsOpen={defaultIsOpen}
             mb="1rem"
+            {...props}
           />
         );
       } else {
@@ -191,6 +189,7 @@ export const ChakraUIRenderer = (
             copyButton={true}
             defaultIsOpen={defaultIsOpen}
             mb="1rem"
+            {...props}
           />
         );
       }
@@ -202,8 +201,8 @@ export const ChakraUIRenderer = (
         </Text>
       );
     },
-    hr: () => {
-      return <Divider my="0.5rem" />;
+    hr: ({ node, children, ...props }) => {
+      return <Divider my="0.5rem" {...props} />;
     },
     a: ({ node, ...props }) => {
       if (props.href && isRelativeUrl(props.href) && !isHashUrl(props.href)) {
@@ -219,7 +218,11 @@ export const ChakraUIRenderer = (
       );
     },
     text: ({ node, children, ...props }) => {
-      return <Text as="span">{children}</Text>;
+      return (
+        <Text as="span" {...props['data-sourcepos']}>
+          {children}
+        </Text>
+      );
     },
     ol: getList,
     ul: getList,
@@ -263,20 +266,24 @@ export const ChakraUIRenderer = (
         </Zoom>
       );
     },
-    thead: ({ children }) => {
+    thead: ({ children, ...props }) => {
       return <Thead>{children}</Thead>;
     },
-    tbody: ({ children }) => {
+    tbody: ({ children, ...props }) => {
       return <Tbody>{children}</Tbody>;
     },
-    tr: ({ children }) => {
+    tr: ({ children, ...props }) => {
       return <Tr>{children}</Tr>;
     },
     th: ({ node, children, ...props }) => {
       return <Th textAlign={props?.style?.textAlign}>{children}</Th>;
     },
     td: ({ node, children, ...props }) => {
-      return <Td textAlign={props?.style?.textAlign}>{children}</Td>;
+      return (
+        <Td textAlign={props?.style?.textAlign} {...props['data-sourcepos']}>
+          {children}
+        </Td>
+      );
     },
     section: ({ node, children, ...props }) => {
       if (props.className === 'footnotes') {
@@ -295,7 +302,7 @@ export const ChakraUIRenderer = (
     badge: ({ node, children, ...props }) => {
       return <Badge {...props}>{children}</Badge>;
     },
-    katex: ({ math, block }) => {
+    katex: ({ math, block, ...props }) => {
       return (
         <Zoom>
           <KaTeXRendererAsync math={math} block={block} />
@@ -308,6 +315,7 @@ export const ChakraUIRenderer = (
           fullName={props.fullName}
           options={{ ...destringObject(props), dispatchSearch: false }}
           mb="1rem"
+          {...props}
         />
       );
     },
@@ -328,6 +336,7 @@ export const ChakraUIRenderer = (
           sort={sort}
           options={{ ...destringObject(props), dispatchSearch: false }}
           mb="1rem"
+          {...props}
         />
       );
     },
@@ -359,15 +368,27 @@ export const ChakraUIRenderer = (
     // Fallbacks for unrecognized directives
     textdirective: ({ node, children, ...props }) => {
       // Unrecognized text directive
-      return <Text as="span">:{props.name}</Text>;
+      return (
+        <Text as="span" {...props}>
+          :{props.name}
+        </Text>
+      );
     },
     leafdirective: ({ node, children, ...props }) => {
       // Unrecognized leaf directive
-      return <Text as="span">::{props.name}</Text>;
+      return (
+        <Text as="span" {...props}>
+          ::{props.name}
+        </Text>
+      );
     },
     containerdirective: ({ node, children, ...props }) => {
       // Unrecognized container directive
-      return <Text as="span">:::{props.name}</Text>;
+      return (
+        <Text as="span" {...props}>
+          :::{props.name}
+        </Text>
+      );
     },
 
     ...customRenderers

--- a/packages/frontend/src/components/markdown-container/markdown-container.tsx
+++ b/packages/frontend/src/components/markdown-container/markdown-container.tsx
@@ -111,7 +111,7 @@ export const MarkdownContainer = memo(
     );
 
     return (
-      <Box {...boxProps} className="iex-markdown-container">
+      <Box overflow="scroll" overflowX="hidden" {...boxProps}>
         <ErrorBoundary FallbackComponent={ErrorFallback}>
           <ReactMarkdown
             children={contents}
@@ -141,6 +141,7 @@ export const MarkdownContainer = memo(
             ]}
             transformLinkUri={transformLinkUri ?? defaultTransformLinkUri}
             transformImageUri={transformAssetUri ?? defaultTransformAssetUri}
+            sourcePos={true}
           />
         </ErrorBoundary>
       </Box>

--- a/packages/frontend/src/components/markdown-split-editor/markdown-split-editor.tsx
+++ b/packages/frontend/src/components/markdown-split-editor/markdown-split-editor.tsx
@@ -32,7 +32,9 @@ import {
   Stack,
   Text,
   Tooltip,
-  Box
+  Box,
+  Checkbox,
+  HStack
 } from '@chakra-ui/react';
 import { ReactNode, useEffect, useRef, useState } from 'react';
 
@@ -140,6 +142,8 @@ export const MarkdownSplitEditor = ({
 
   const [isPreviewMode, setPreviewMode] = useState(false);
 
+  const [scrollSync, setScrollSync] = useState(false);
+
   // Overwrite internal state if external contents change
   useEffect(() => {
     setInternalValue(contents);
@@ -166,7 +170,18 @@ export const MarkdownSplitEditor = ({
   return (
     <Flex {...flexProps} direction="column">
       <Flex direction="row" justify="flex-end" pr="0.25rem">
-        {showFormattingHelp && <FormattingHelp />}
+        <HStack spacing="1rem" align="stretch">
+          <Checkbox
+            isChecked={scrollSync}
+            onChange={() => setScrollSync(!scrollSync)}
+            size="sm"
+            color="frost.400"
+            fontWeight={'medium'}
+          >
+            {'Enable Scroll Sync (experimental)'}
+          </Checkbox>
+          {showFormattingHelp && <FormattingHelp />}
+        </HStack>
         {showPreview && (
           <Box display={{ base: 'block', xl: 'none' }} ml="1rem">
             {isPreviewMode && (
@@ -192,14 +207,19 @@ export const MarkdownSplitEditor = ({
           </Box>
         )}
       </Flex>
-      <Flex direction="row" flexGrow={1}>
+      <Flex direction="row" flexGrow={1} maxH={scrollSync ? '60vh' : '100%'} overflow="hidden">
         <Box
           position="relative"
           flexGrow={1}
           width="100%"
           display={{ base: isPreviewMode ? 'none' : 'block', xl: 'block' }}
         >
-          <MarkdownEditor contents={contents} onContentsChange={setInternalValue} uploadFile={uploadFile} />
+          <MarkdownEditor
+            contents={contents}
+            onContentsChange={setInternalValue}
+            uploadFile={uploadFile}
+            scrollSync={scrollSync}
+          />
         </Box>
         {showPreview && (
           <MarkdownContainer

--- a/packages/frontend/src/pages/admin-page/components/news-admin/components/news-item/news-item.tsx
+++ b/packages/frontend/src/pages/admin-page/components/news-admin/components/news-item/news-item.tsx
@@ -20,7 +20,6 @@ import { useState } from 'react';
 import { Components } from 'react-markdown';
 
 import { Card } from '../../../../../../components/card/card';
-import { getCoreProps } from '../../../../../../components/markdown-container/chakra-ui-renderer';
 import { MarkdownContainer } from '../../../../../../components/markdown-container/markdown-container';
 import { NewsFieldsFragment } from '../../../../../../models/generated/graphql';
 import { formatDateIntl } from '../../../../../../shared/date-utils';
@@ -29,7 +28,7 @@ import { EditNewsItem } from '../edit-news-item/edit-news-item';
 const heading = ({ node, children, level, ...props }) => {
   const sizes = ['1.4rem', '1.2rem', '1.1rem', '1rem', '0.8rem', '0.6rem'];
   return (
-    <Heading as={`h${level}`} size={sizes[level - 1]} {...getCoreProps(props)}>
+    <Heading as={`h${level}`} size={sizes[level - 1]} {...props['data-sourcepos']}>
       {children}
     </Heading>
   );

--- a/packages/frontend/src/pages/main-page/components/header/components/news-drawer/components/news-item/news-item.tsx
+++ b/packages/frontend/src/pages/main-page/components/header/components/news-drawer/components/news-item/news-item.tsx
@@ -21,7 +21,6 @@ import { Components } from 'react-markdown';
 import { Card } from '../../../../../../../../components/card/card';
 import { LikeButton } from '../../../../../../../../components/like-button/like-button';
 import { LikedByTooltip } from '../../../../../../../../components/liked-by-tooltip/liked-by-tooltip';
-import { getCoreProps } from '../../../../../../../../components/markdown-container/chakra-ui-renderer';
 import { MarkdownContainer } from '../../../../../../../../components/markdown-container/markdown-container';
 import { News, User } from '../../../../../../../../models/generated/graphql';
 import { formatDateIntl } from '../../../../../../../../shared/date-utils';
@@ -29,7 +28,7 @@ import { formatDateIntl } from '../../../../../../../../shared/date-utils';
 const heading = ({ node, children, level, ...props }) => {
   const sizes = ['1.4rem', '1.2rem', '1.1rem', '1rem', '0.8rem', '0.6rem'];
   return (
-    <Heading as={`h${level}`} size={sizes[level - 1]} {...getCoreProps(props)}>
+    <Heading as={`h${level}`} size={sizes[level - 1]} {...props['data-sourcepos']}>
       {children}
     </Heading>
   );


### PR DESCRIPTION
This PR adds an experimental feature to be able to scroll the Markdown editor and the Markdown preview containers independently, and adding the functionality to synchronize the scroll position from the editor to the preview based on the position of the Markdown component.


