### PR TITLE
feat: Manually specify authors for an Insight

### DIFF
--- a/packages/backend/schema.gql
+++ b/packages/backend/schema.gql
@@ -170,6 +170,7 @@ type Insight {
   collaborators: UserPermissionConnection
   commentCount: Float!
   comments: CommentConnection
+  config: InsightConfig
   createdAt: String!
   creation: InsightCreation
   description: String!
@@ -206,6 +207,11 @@ type InsightCollaboratorActivityDetails {
   insight: Insight
   permission: String!
   user: User!
+}
+
+type InsightConfig {
+  authors: [String!]
+  excludedAuthors: [String!]
 }
 
 type InsightConnection {

--- a/packages/backend/src/lib/git-instance.ts
+++ b/packages/backend/src/lib/git-instance.ts
@@ -116,6 +116,15 @@ export class GitInstance {
     }
   }
 
+  async latestCommitHash(): Promise<string> {
+    if (this.localPath === undefined) {
+      throw new Error('[GIT_INSTANCE] Git repository not cloned!');
+    }
+
+    const commits = await git.log({ fs, dir: this.localPath, ref: 'HEAD', depth: 1 });
+    return commits[0].oid;
+  }
+
   fileExists(filePath: string): boolean {
     if (this.localPath === undefined) {
       throw new Error('[GIT_INSTANCE] Git repository not cloned!');
@@ -241,7 +250,7 @@ export class GitInstance {
       author,
       message
     });
-    logger.debug('Commit SHA: ' + sha);
+    logger.info(`[GIT_INSTANCE] Commit SHA: ${sha}`);
 
     return sha;
   }

--- a/packages/backend/src/models/draft.ts
+++ b/packages/backend/src/models/draft.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { IndexedInsightConfig } from '@iex/models/indexed/indexed-insight-config';
 import GraphQLJSON from 'graphql-type-json';
 import { Field, ObjectType, InputType, ID } from 'type-graphql';
 
@@ -25,7 +26,10 @@ export type DraftKey = string;
 
 export type DraftData = Partial<Insight> & { commitMessage?: string };
 
-export type DraftDataInput = Partial<UpdatedInsight> & { commitMessage?: string; initializedTemplate?: boolean };
+export type DraftDataInput = Partial<UpdatedInsight> & {
+  commitMessage?: string;
+  initializedTemplate?: boolean;
+} & IndexedInsightConfig;
 
 @ObjectType()
 export class Draft extends BaseModel {

--- a/packages/backend/src/models/insight.ts
+++ b/packages/backend/src/models/insight.ts
@@ -15,6 +15,7 @@
  */
 
 import { IndexedInsight } from '@iex/models/indexed/indexed-insight';
+import { IndexedInsightConfig } from '@iex/models/indexed/indexed-insight-config';
 import { IndexedInsightCreation } from '@iex/models/indexed/indexed-insight-creation';
 import { IndexedInsightMetadata } from '@iex/models/indexed/indexed-insight-metadata';
 import { ItemType } from '@iex/models/item-type';
@@ -63,6 +64,15 @@ export class InsightMetadata implements IndexedInsightMetadata {
 
   @Field({ nullable: true })
   team?: string;
+}
+
+@ObjectType()
+export class InsightConfig implements IndexedInsightConfig {
+  @Field(() => [String], { nullable: true })
+  authors?: string[];
+
+  @Field(() => [String], { nullable: true })
+  excludedAuthors?: string[];
 }
 
 @InputType()
@@ -137,6 +147,9 @@ export class Insight implements IndexedInsight {
 
   @Field({ nullable: true })
   metadata?: InsightMetadata;
+
+  @Field({ nullable: true })
+  config?: InsightConfig;
 
   @Field(() => CommentConnection, { nullable: true })
   comments?: CommentConnection;

--- a/packages/backend/src/services/insight.service.ts
+++ b/packages/backend/src/services/insight.service.ts
@@ -498,13 +498,15 @@ export class InsightService {
             // Merge the existing data with any fields specified in the update
             // This variable is hoisted so the merged version can be used to update
             // the GitHub API as well.
-            const { creation, description, itemType, metadata, name, tags } = updatedYaml;
+            const { authors, creation, description, excludedAuthors, itemType, metadata, name, tags } = updatedYaml;
             mergedYaml = {
               ...insightYaml,
               name,
               description,
               itemType,
-              tags
+              tags,
+              authors,
+              excludedAuthors
             };
 
             if (creation != null) {
@@ -522,6 +524,14 @@ export class InsightService {
               if (mergedYaml.metadata?.team?.trim() === '') {
                 delete mergedYaml.metadata.team;
               }
+            }
+
+            // Cleanup empty fields
+            if (mergedYaml.authors && mergedYaml.authors.length === 0) {
+              delete mergedYaml.authors;
+            }
+            if (mergedYaml.excludedAuthors && mergedYaml.excludedAuthors.length === 0) {
+              delete mergedYaml.excludedAuthors;
             }
 
             if (mergedYaml) await gitInstance.putInsightYaml(mergedYaml);

--- a/packages/backend/src/services/user.service.ts
+++ b/packages/backend/src/services/user.service.ts
@@ -92,6 +92,15 @@ export class UserService {
   }
 
   /**
+   * Fetches a User by Email.
+   *
+   * @param email User email
+   */
+  async getUserByEmail(email: string): Promise<User | null> {
+    return await User.query().where('email', 'ILIKE', email).first();
+  }
+
+  /**
    * Provides several "health checks" for a user's configuration
    */
   async healthCheck(user: User): Promise<UserHealthCheck> {

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-authors.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-authors.tsx
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2022 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FormControl, FormHelperText, FormLabel, InputGroup, InputLeftElement } from '@chakra-ui/react';
+import { Controller } from 'react-hook-form';
+import CreatableSelect from 'react-select/creatable';
+import { gql, useQuery } from 'urql';
+
+import { UsersAsAuthorsQuery } from '../../../../models/generated/graphql';
+import { iconFactoryAs } from '../../../../shared/icon-factory';
+
+const USERS_QUERY = gql`
+  query UsersAsAuthors {
+    users {
+      id
+      email
+      displayName
+    }
+  }
+`;
+
+export const InsightAuthors = ({ insight, form }) => {
+  const {
+    control,
+    formState: { errors }
+  } = form;
+
+  // Load autocomplete values to populate filters
+  const [{ data: userData }] = useQuery<UsersAsAuthorsQuery>({
+    query: USERS_QUERY
+  });
+
+  const availableAuthors = userData?.users?.map(({ email, displayName }) => ({ value: email, label: displayName }));
+
+  return (
+    <>
+      <FormControl id="insight-authors" isInvalid={errors.authors !== undefined}>
+        <FormLabel>Authors</FormLabel>
+        <InputGroup>
+          <InputLeftElement pointerEvents="none" children={iconFactoryAs('user', { color: 'frost.400' })} />
+          <Controller
+            control={control}
+            name="authors"
+            defaultValue={insight?.config?.authors ?? []}
+            render={({ field: { onBlur, onChange, value } }) => (
+              <CreatableSelect
+                inputId="authors"
+                isMulti
+                isClearable
+                options={availableAuthors}
+                onChange={(event) => {
+                  let values: string[] = [];
+                  if (event != null) {
+                    values = event.map((e) => e.value);
+                  }
+                  onChange(values);
+                }}
+                value={value.map((author: string) => ({ value: author, label: author }))}
+                styles={{
+                  menu: (base) => ({ ...base, zIndex: 11 }),
+                  menuPortal: (base) => ({ ...base, zIndex: 11 }),
+                  container: (base) => ({ ...base, width: '100%' }),
+                  valueContainer: (base) => ({ ...base, paddingLeft: '40px' })
+                }}
+              />
+            )}
+          />
+        </InputGroup>
+        <FormHelperText>
+          If provided, this field will overwrite the auto-detected list of Authors.
+          <br />
+          Specify one or more email addresses.
+        </FormHelperText>
+      </FormControl>
+
+      <FormControl id="insight-excluded-authors" isInvalid={errors.excludedAuthors !== undefined}>
+        <FormLabel>Exclude Authors</FormLabel>
+        <InputGroup>
+          <InputLeftElement pointerEvents="none" children={iconFactoryAs('user', { color: 'frost.400' })} />
+          <Controller
+            control={control}
+            name="excludedAuthors"
+            defaultValue={insight?.config?.excludedAuthors ?? []}
+            render={({ field: { onBlur, onChange, value } }) => (
+              <CreatableSelect
+                inputId="excludedAuthors"
+                isMulti
+                isClearable
+                options={availableAuthors}
+                onChange={(event) => {
+                  let values: string[] = [];
+                  if (event != null) {
+                    values = event.map((e) => e.value);
+                  }
+                  onChange(values);
+                }}
+                value={value.map((author: string) => ({ value: author, label: author }))}
+                styles={{
+                  menu: (base) => ({ ...base, zIndex: 11 }),
+                  menuPortal: (base) => ({ ...base, zIndex: 11 }),
+                  container: (base) => ({ ...base, width: '100%' }),
+                  valueContainer: (base) => ({ ...base, paddingLeft: '40px' })
+                }}
+              />
+            )}
+          />
+        </InputGroup>
+        <FormHelperText>
+          Authors specified here will be ignored when auto-detecting authors.
+          <br />
+          Specify one or more email addresses.
+        </FormHelperText>
+      </FormControl>
+    </>
+  );
+};

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-metadata-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-metadata-editor.tsx
@@ -15,14 +15,21 @@
  */
 
 import {
+  Collapse,
+  Divider,
   FormControl,
   FormErrorMessage,
   FormHelperText,
   FormLabel,
+  Heading,
+  HStack,
   Icon,
+  IconButton,
   Input,
   InputGroup,
   InputRightElement,
+  Text,
+  useDisclosure,
   VStack
 } from '@chakra-ui/react';
 import { useEffect } from 'react';
@@ -34,10 +41,11 @@ import { gql, useQuery } from 'urql';
 import { Alert } from '../../../../components/alert/alert';
 import { Insight } from '../../../../models/generated/graphql';
 import { formatFormError } from '../../../../shared/form-utils';
-import { iconFactory } from '../../../../shared/icon-factory';
+import { iconFactory, iconFactoryAs } from '../../../../shared/icon-factory';
 import { ItemType } from '../../../../shared/item-type';
 import { DraftForm } from '../../draft-form';
 
+import { InsightAuthors } from './insight-authors';
 import { InsightTags } from './insight-tags';
 import { InsightTeam } from './insight-team';
 import { PublishedDate } from './published-date';
@@ -65,6 +73,8 @@ export const InsightMetadataEditor = ({ insight, isNewInsight, form, templates, 
     register,
     formState: { errors }
   } = form;
+
+  const { isOpen: isAdvancedOpen, onToggle: onAdvancedToggle } = useDisclosure({ defaultIsOpen: false });
 
   const isCloned = insight.creation?.clonedFrom != null;
 
@@ -94,7 +104,7 @@ export const InsightMetadataEditor = ({ insight, isNewInsight, form, templates, 
   }, [register]);
 
   return (
-    <VStack spacing="1rem" p="1rem">
+    <VStack spacing="1rem" p="1rem" align="stretch">
       {isNewInsight && isCloned && (
         <Alert
           mb="2rem"
@@ -187,6 +197,33 @@ export const InsightMetadataEditor = ({ insight, isNewInsight, form, templates, 
       <InsightTeam insight={insight} form={form} />
 
       {itemType === 'insight' && <PublishedDate insight={insight} form={form} />}
+
+      <Divider />
+
+      <HStack justify="space-between" onClick={onAdvancedToggle}>
+        <Heading fontSize="md" fontWeight="bold">
+          Advanced
+        </Heading>
+        <IconButton
+          aria-label="Expand/collapse"
+          icon={isAdvancedOpen ? iconFactoryAs('chevronUp') : iconFactoryAs('chevronDown')}
+          variant="ghost"
+          size="sm"
+          title={isAdvancedOpen ? 'Collapse this section' : 'Expand this section'}
+        />
+      </HStack>
+
+      <Collapse in={isAdvancedOpen} animateOpacity>
+        <VStack spacing="1rem" align="stretch">
+          <HStack align="center">
+            {iconFactoryAs('warning', { color: 'aurora.200' })}
+
+            <Text fontSize="sm">These settings typically don't need to be changed.</Text>
+          </HStack>
+
+          <InsightAuthors insight={insight} form={form} />
+        </VStack>
+      </Collapse>
     </VStack>
   );
 };

--- a/packages/frontend/src/shared/useInsight.ts
+++ b/packages/frontend/src/shared/useInsight.ts
@@ -80,6 +80,10 @@ const INSIGHT_FRAGMENT = gql`
       team
       publishedDate
     }
+    config {
+      authors
+      excludedAuthors
+    }
     files {
       id
       name

--- a/packages/frontend/src/urql.ts
+++ b/packages/frontend/src/urql.ts
@@ -62,6 +62,7 @@ export const urqlClient = createClient({
         GitHubSettings: () => null,
         InsightActivityDetails: () => null,
         InsightCollaboratorActivityDetails: () => null,
+        InsighgtConfig: () => null,
         InsightCreation: () => null,
         InsightFile: () => null,
         InsightFileConversion: () => null,

--- a/packages/models/src/indexed/indexed-insight-config.ts
+++ b/packages/models/src/indexed/indexed-insight-config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Expedia, Inc.
+ * Copyright 2022 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,7 @@
  * limitations under the License.
  */
 
-import { ItemType } from '@iex/models/item-type';
-
-export interface InsightYaml {
-  name?: string;
-  description?: string;
-  tags?: string[];
-  itemType?: ItemType;
-  creation?: {
-    template?: string;
-    clonedFrom?: string;
-  };
-  metadata?: {
-    publishedDate?: string;
-    team?: string;
-  };
+export interface IndexedInsightConfig {
   authors?: string[];
   excludedAuthors?: string[];
 }

--- a/packages/models/src/indexed/indexed-insight.ts
+++ b/packages/models/src/indexed/indexed-insight.ts
@@ -16,6 +16,7 @@
 
 import type { ItemType } from '../item-type';
 
+import type { IndexedInsightConfig } from './indexed-insight-config';
 import type { IndexedInsightCreation } from './indexed-insight-creation';
 import type { IndexedInsightFile } from './indexed-insight-file';
 import type { IndexedInsightMetadata } from './indexed-insight-metadata';
@@ -58,4 +59,6 @@ export interface IndexedInsight {
   creation?: IndexedInsightCreation;
 
   metadata?: IndexedInsightMetadata;
+
+  config?: IndexedInsightConfig;
 }


### PR DESCRIPTION
This change adds two optional YAML configs, `authors` and `excludedAuthors`. These properties modify the default sync behavior of extracting authors from the git repository.

Both properties can be modified in the Insight Editor UI, under an _Advanced_ section.

- `authors`: Contains a list of one or more email addresses that should be used exclusively as the authors of the Insight.  These emails will be linked to IEX users where possible.
- `excludedAuthors`: Contains a list of one or more email addresses to exclude from the auto-generated list of authors.  Useful if someone has made a change on an Insight, but shouldn't be considered an author (e.g. an Admin)