### PR TITLE
Fix markdown editor UI issues

### DIFF
--- a/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
+++ b/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useBreakpointValue } from '@chakra-ui/media-query';
 import { useColorModeValue } from '@chakra-ui/react';
 import { nanoid } from 'nanoid';
 import { emoji } from 'node-emoji';
@@ -144,6 +145,8 @@ export const MarkdownEditor = ({ contents, onContentsChange, scrollSync, uploadF
     [internalValue]
   );
 
+  const aceEditorHeight = useBreakpointValue({ base: undefined, xl: scrollSync ? '70vh' : '100%' });
+
   return (
     <AceEditor
       name="aceEditor"
@@ -159,7 +162,8 @@ export const MarkdownEditor = ({ contents, onContentsChange, scrollSync, uploadF
       showPrintMargin={false}
       width="100%"
       minLines={30}
-      height={scrollSync ? '70vh' : '100%'}
+      maxLines={scrollSync ? undefined : Infinity}
+      height={aceEditorHeight}
       setOptions={{
         scrollPastEnd: scrollSync,
         autoScrollEditorIntoView: true,

--- a/packages/frontend/src/components/markdown-split-editor/markdown-split-editor.tsx
+++ b/packages/frontend/src/components/markdown-split-editor/markdown-split-editor.tsx
@@ -169,19 +169,18 @@ export const MarkdownSplitEditor = ({
 
   return (
     <Flex {...flexProps} direction="column">
-      <Flex direction="row" justify="flex-end" pr="0.25rem">
-        <HStack spacing="1rem" align="stretch">
-          <Checkbox
-            isChecked={scrollSync}
-            onChange={() => setScrollSync(!scrollSync)}
-            size="sm"
-            color="frost.400"
-            fontWeight={'medium'}
-          >
-            {'Enable Scroll Sync (experimental)'}
-          </Checkbox>
-          {showFormattingHelp && <FormattingHelp />}
-        </HStack>
+      <HStack justify="flex-end" spacing="0.5rem">
+        <Checkbox
+          isChecked={scrollSync}
+          onChange={() => setScrollSync(!scrollSync)}
+          size="sm"
+          color="frost.400"
+          fontWeight={'medium'}
+          display={{ base: 'none', xl: 'flex' }}
+        >
+          {'Enable Scroll Sync (experimental)'}
+        </Checkbox>
+        {showFormattingHelp && <FormattingHelp />}
         {showPreview && (
           <Box display={{ base: 'block', xl: 'none' }} ml="1rem">
             {isPreviewMode && (
@@ -206,7 +205,7 @@ export const MarkdownSplitEditor = ({
             )}
           </Box>
         )}
-      </Flex>
+      </HStack>
       <Flex direction="row" flexGrow={1} maxH={scrollSync ? '60vh' : '100%'} overflow="hidden">
         <Box
           position="relative"


### PR DESCRIPTION
This PR fixes an issue with the Markdown Editor when on responsive style it hides the editor from the view. 
This also hides the Scroll Sync checkbox when the Split Editor is not showing both the Editor and Preview.

Original:
<img src="https://user-images.githubusercontent.com/1399744/156654029-a6e99a0a-9852-4ed1-8bbb-1ea8b6fdf936.png" width="700px" /> 

Changes:
<img src="https://user-images.githubusercontent.com/1399744/156654081-e9eac78a-c7a5-41ff-a0bb-3e9c2ba4ab72.png" width="700px" />

