### PR TITLE
fix: Mobile-friendly Error pages and Alerts

### DIFF
--- a/packages/frontend/src/components/alert/alert.tsx
+++ b/packages/frontend/src/components/alert/alert.tsx
@@ -85,7 +85,7 @@ export const Alert = ({
       {icon && <AlertIcon as={icon} flexShrink={0} />}
       {icon === undefined && <AlertIcon flexShrink={0} />}
 
-      <Flex wordBreak="break-word" flexGrow={2} align="center">
+      <Flex wordBreak="break-word" flexGrow={2} align="center" fontSize={{ base: 'sm', md: 'md' }}>
         <Text as="strong" mr="0.5rem" flexShrink={0}>
           {startCase(derivedStatus)}:{' '}
         </Text>

--- a/packages/frontend/src/pages/error-page/error-page.tsx
+++ b/packages/frontend/src/pages/error-page/error-page.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useBreakpointValue } from '@chakra-ui/media-query';
 import { Box, Button, Heading, HStack, Icon, Tag, TagLabel, Text, VStack, Wrap, WrapItem } from '@chakra-ui/react';
 import { ReactChild } from 'react';
 import { Helmet } from 'react-helmet';
@@ -39,6 +40,8 @@ const defaultProps: Required<Props> = {
 export const ErrorPage = (props: Props) => {
   const mergedProps = { ...defaultProps, ...props };
 
+  const tagSize = useBreakpointValue({ base: 'sm', md: 'lg' });
+
   return (
     <>
       <Helmet>
@@ -48,17 +51,17 @@ export const ErrorPage = (props: Props) => {
       <VStack as={Card} align="center" p="3rem">
         <Wrap spacing="2rem" align="center" p="2.5rem">
           <WrapItem>
-            <Icon as={mergedProps.icon} fontSize="12rem" color="polar.200" />
+            <Icon as={mergedProps.icon} fontSize={{ base: '6rem', md: '12rem' }} color="polar.200" />
           </WrapItem>
           <WrapItem>
             <VStack spacing="1rem" align="flex-start" maxWidth="36rem">
-              <Tag rounded="full" size="lg" bg="aurora.200" color="polar.100" fontWeight="bold">
+              <Tag rounded="full" size={tagSize} bg="aurora.200" color="polar.100" fontWeight="bold">
                 <TagLabel>{mergedProps.errorCode}</TagLabel>
               </Tag>
-              <Heading color="polar.200" fontSize="4rem">
+              <Heading color="polar.200" fontSize={{ base: '2rem', md: '4rem' }}>
                 {mergedProps.heading}
               </Heading>
-              <Text fontSize="1.4rem">{mergedProps.message}</Text>
+              <Text fontSize={{ base: '1rem', md: '1.4rem' }}>{mergedProps.message}</Text>
 
               <HStack>
                 <Button variant="frost" onClick={() => window.history.go(-1)}>

--- a/packages/frontend/src/pages/insight-editor/insight-draft-switcher.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-draft-switcher.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useBreakpointValue } from '@chakra-ui/media-query';
 import {
   Alert as ChakraAlert,
   AlertIcon,
@@ -100,6 +101,8 @@ export const InsightDraftSwitcher = ({ insight, onRefresh }) => {
   const hasDraftKey = draftKey !== '';
   const { isOpen, onToggle } = useDisclosure();
 
+  const buttonSize = useBreakpointValue({ base: 'sm', md: 'md' });
+
   const { userInfo } = useSelector((state: RootState) => state.user);
 
   // Existing In-Progress Drafts
@@ -182,7 +185,7 @@ export const InsightDraftSwitcher = ({ insight, onRefresh }) => {
         (!hasDraftKey && pendingDrafts.length > 0)) && (
         <ChakraAlert status="info" borderRadius="0.25rem" mb="1rem" alignItems="flex-start" wordBreak="break-word">
           <AlertIcon flexShrink={0} />
-          <VStack spacing="1rem" align="stretch" flexGrow={2}>
+          <VStack spacing="1rem" align="stretch" flexGrow={2} fontSize={{ base: 'sm', md: 'md' }}>
             {!hasDraftKey && (
               <Text>
                 <strong>Info:</strong> You have {pendingDrafts.length} unpublished draft
@@ -258,7 +261,7 @@ export const InsightDraftSwitcher = ({ insight, onRefresh }) => {
                   </Flex>
                 </Box>
                 {!hasDraftKey && (
-                  <Button variant="solid" bg="frost.300" onClick={createNewDraft}>
+                  <Button variant="solid" bg="frost.300" onClick={createNewDraft} size={buttonSize}>
                     Create a New Draft
                   </Button>
                 )}

--- a/packages/frontend/src/pages/main-page/components/user-health-check/user-health-check.tsx
+++ b/packages/frontend/src/pages/main-page/components/user-health-check/user-health-check.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Alert as ChakraAlert, AlertIcon, Badge, Box, BoxProps, Button, HStack, Text } from '@chakra-ui/react';
+import { Alert as ChakraAlert, AlertIcon, Badge, Box, BoxProps, Button, Stack, Text } from '@chakra-ui/react';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -32,17 +32,17 @@ const HealthCheckAlert = ({ children, allowRecheck = true }) => {
   return (
     <ChakraAlert status="warning" borderRadius="0.25rem" mb="1rem" alignItems="flex-start" wordBreak="break-word">
       <AlertIcon flexShrink={0} />
-      <HStack spacing="0.5rem" align="flex-start">
+      <Stack direction={{ base: 'column', md: 'row' }} spacing="0.5rem" align="flex-start">
         <Text as="strong" flexShrink={0}>
           Warning:
         </Text>
         {children}
         {allowRecheck && (
-          <Button size="sm" bg="snowstorm.100" flexShrink={0} onClick={onRecheck}>
+          <Button size="xs" bg="snowstorm.100" flexShrink={0} onClick={onRecheck}>
             Recheck
           </Button>
         )}
-      </HStack>
+      </Stack>
     </ChakraAlert>
   );
 };
@@ -77,7 +77,7 @@ export const UserHealthCheck = ({
     false;
 
   return (
-    <Box {...boxProps}>
+    <Box {...boxProps} fontSize={{ base: 'sm' }}>
       {showPositiveChecks && gitHubTokenValid && <Alert success="Your GitHub Personal Access Token is valid" />}
       {!healthCheck.hasGitHubToken && (
         <HealthCheckAlert allowRecheck={false}>

--- a/packages/frontend/src/pages/main-page/components/user-health-check/user-health-check.tsx
+++ b/packages/frontend/src/pages/main-page/components/user-health-check/user-health-check.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useBreakpointValue } from '@chakra-ui/media-query';
 import { Alert as ChakraAlert, AlertIcon, Badge, Box, BoxProps, Button, Stack, Text } from '@chakra-ui/react';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -29,6 +30,8 @@ const HealthCheckAlert = ({ children, allowRecheck = true }) => {
 
   const onRecheck = () => dispatch(executeHealthCheck());
 
+  const buttonSize = useBreakpointValue({ base: 'xs', md: 'sm' });
+
   return (
     <ChakraAlert status="warning" borderRadius="0.25rem" mb="1rem" alignItems="flex-start" wordBreak="break-word">
       <AlertIcon flexShrink={0} />
@@ -38,7 +41,7 @@ const HealthCheckAlert = ({ children, allowRecheck = true }) => {
         </Text>
         {children}
         {allowRecheck && (
-          <Button size="xs" bg="snowstorm.100" flexShrink={0} onClick={onRecheck}>
+          <Button size={buttonSize} bg="snowstorm.100" flexShrink={0} onClick={onRecheck}>
             Recheck
           </Button>
         )}
@@ -77,7 +80,7 @@ export const UserHealthCheck = ({
     false;
 
   return (
-    <Box {...boxProps} fontSize={{ base: 'sm' }}>
+    <Box {...boxProps} fontSize={{ base: 'sm', md: 'md' }}>
       {showPositiveChecks && gitHubTokenValid && <Alert success="Your GitHub Personal Access Token is valid" />}
       {!healthCheck.hasGitHubToken && (
         <HealthCheckAlert allowRecheck={false}>


### PR DESCRIPTION
This PR improves the mobile-responsive design of the Error pages and alerts so components can be shown correctly.

**Insight Error Page**
<img src="https://user-images.githubusercontent.com/1399744/156863410-7004e2b6-aa9d-4587-8c97-5afe15a04c1d.png" width="300px" /> <img src="https://user-images.githubusercontent.com/1399744/156863420-894d3299-83e7-4a21-a25f-96278848d5ad.png" width="300px" />

**User Error Page**
<img src="https://user-images.githubusercontent.com/1399744/156863462-836f8fc8-1cac-4067-963e-5170b0ea0221.png" width="300px" /> <img src="https://user-images.githubusercontent.com/1399744/156863468-18749f5d-95f3-4e0f-b2ee-9b027bdb3d57.png" width="300px" />

**Default Error Page**
<img src="https://user-images.githubusercontent.com/1399744/156863500-f51e5886-69b0-4708-af3e-350fbf11c340.png" width="300px" /> <img src="https://user-images.githubusercontent.com/1399744/156863504-24c54401-701f-4f6a-bfc9-2d7e11ff2c1d.png" width="300px" />

**Alerts**
<img src="https://user-images.githubusercontent.com/1399744/156863541-b944a624-1b72-49af-ae08-1638752fdc99.png" width="300px" /> <img src="https://user-images.githubusercontent.com/1399744/156863545-fc556aa7-6f05-495d-8b1a-323de00a8702.png" width="300px" />




