### PR TITLE
fix: Mobile-responsive Admin Page

### DIFF
--- a/packages/frontend/src/components/settings-sidebar/settings-sidebar.tsx
+++ b/packages/frontend/src/components/settings-sidebar/settings-sidebar.tsx
@@ -48,7 +48,7 @@ export const SettingsSidebar = ({ bottomContent, sections, title = 'Settings' }:
   return (
     <VStack
       spacing="1rem"
-      flexBasis="16rem"
+      flexBasis={{ base: '8rem', md: '16rem' }}
       flexShrink={0}
       maxWidth={{ base: '100%', md: '16rem' }}
       p="1rem"

--- a/packages/frontend/src/pages/admin-page/admin-page.tsx
+++ b/packages/frontend/src/pages/admin-page/admin-page.tsx
@@ -33,7 +33,7 @@ export const AdminPage = () => {
       </Helmet>
 
       <Flex direction="column" justify="stretch" flexGrow={2}>
-        <Flex direction="row" mt="1rem" flexGrow={2}>
+        <Flex direction={{ base: 'column', md: 'row' }} mt="1rem" flexGrow={2}>
           <SettingsSidebar title="Admin" sections={adminSections} />
 
           <VStack align="stretch" flexGrow={2}>


### PR DESCRIPTION
This PR improves the mobile-responsive design of the Admin page so components can be shown correctly.

Note: The fix is also related to changes from #547 