### PR TITLE
fix: Update Insight search to exclude non-matching documents

### DIFF
--- a/packages/shared/src/search.ts
+++ b/packages/shared/src/search.ts
@@ -15,6 +15,7 @@
  */
 
 import type { SearchQuery } from '@iex/models/elasticsearch';
+import { isObject } from 'lodash';
 import isArray from 'lodash/isArray';
 import mergeWith from 'lodash/mergeWith';
 import Parsimmon, { optWhitespace } from 'parsimmon';
@@ -86,6 +87,7 @@ export class SearchMatch implements SearchClause {
   toElasticsearch(): any {
     return {
       bool: {
+        minimum_should_match: 1,
         should: [
           {
             multi_match: {
@@ -115,6 +117,7 @@ export class SearchPhrase implements SearchClause {
   toElasticsearch(): any {
     return {
       bool: {
+        minimum_should_match: 1,
         should: [
           {
             multi_match: {
@@ -387,10 +390,13 @@ export function parseSearchQuery(searchQuery: string): SearchClause[] {
   return clauses;
 }
 
-const mergeCustomizer = (objectValue: any, sourceValue: any) => {
+const mergeCustomizer = (objectValue: any, sourceValue: any): any => {
   // Concat arrays together
   if (isArray(objectValue)) {
     return [...objectValue, ...sourceValue];
+  }
+  if (isObject(objectValue)) {
+    return mergeWith(objectValue, sourceValue, mergeCustomizer);
   }
 };
 

--- a/packages/shared/test/search.test.ts
+++ b/packages/shared/test/search.test.ts
@@ -299,14 +299,20 @@ describe('search', () => {
       const clauses: any[] = parseSearchQuery('avocado');
       const es = toElasticsearch(clauses);
       expect(es).toMatchObject({
-        bool: { should: [{ multi_match: { query: 'avocado' } }] }
+        bool: {
+          minimum_should_match: 1,
+          should: [{ multi_match: { query: 'avocado' } }]
+        }
       });
     });
     test('two words', () => {
       const clauses: any[] = parseSearchQuery('avocado toast');
       const es = toElasticsearch(clauses);
       expect(es).toMatchObject({
-        bool: { should: [{ multi_match: { query: 'avocado' } }, { multi_match: { query: 'toast' } }] }
+        bool: {
+          minimum_should_match: 1,
+          should: [{ multi_match: { query: 'avocado' } }, { multi_match: { query: 'toast' } }]
+        }
       });
     });
     test('word and tag', () => {
@@ -314,6 +320,7 @@ describe('search', () => {
       const es = toElasticsearch(clauses);
       expect(es).toMatchObject({
         bool: {
+          minimum_should_match: 1,
           filter: [{ term: { 'tags.keyword': { value: 'demo' } } }],
           should: [{ multi_match: { query: 'insight' } }]
         }
@@ -395,6 +402,7 @@ describe('search', () => {
       const es = parseToElasticsearch('"best practice" tag:demo insight');
       expect(es).toMatchObject({
         bool: {
+          minimum_should_match: 1,
           filter: [{ term: { 'tags.keyword': { value: 'demo' } } }],
           should: [
             {


### PR DESCRIPTION
Previously, Insights could be included in the results due to a `filter` match like `itemType: insight`, even if they didn't match any search terms.  This resulted in a score of `0.0`, but these documents would still appear in the search page.

This change adds the `minimum_should_match` field to the SearchMatch and SearchPhrase terms.  It will ensure that matching documents match at least one of the `should` clauses.  Searches without any `should` clauses (e.g. #tag) won't be affected.