### PR TITLE
refactor: Remove unnecessary use of `w`/`h` attributes

### DIFF
--- a/packages/frontend/src/components/markdown-container/iex-markdown-schema.ts
+++ b/packages/frontend/src/components/markdown-container/iex-markdown-schema.ts
@@ -1,5 +1,6 @@
-/** @type {import('./index.js').Schema} */
-export const IexMarkdownSchema = {
+import { Options } from 'rehype-sanitize';
+
+export const IexMarkdownSchema: Options = {
   strip: ['script'],
   clobber: [],
   ancestors: {

--- a/packages/frontend/src/shared/remark/remark-iex.ts
+++ b/packages/frontend/src/shared/remark/remark-iex.ts
@@ -38,15 +38,11 @@ export const remarkIex = (options) => {
         break;
 
       case 'image': {
-        const { height: h, width: w, ...attributes } = node.attributes;
-
         node.data = {
           hName: 'img',
           hProperties: {
             src: node.children[0]?.value ?? node.children[0]?.url,
-            w,
-            h,
-            ...attributes
+            ...node.attributes
           }
         };
 
@@ -176,17 +172,12 @@ export const remarkIex = (options) => {
       }
 
       case 'vega': {
-        // Convert height/width if available
-        const { height: h, width: w, ...attributes } = node.attributes;
-
         node.data = {
           hName: 'vegachart',
           hProperties: {
             // Extract body of node into text
             config: remarkNodetoText(node),
-            w,
-            h,
-            ...attributes
+            ...node.attributes
           }
         };
 
@@ -209,18 +200,13 @@ export const remarkIex = (options) => {
           }
         }
 
-        // Convert height/width if available
-        const { height: h, width: w, ...attributes } = node.attributes;
-
         node.data = {
           hName: 'xkcdchart',
           hProperties: {
             // Extract body of node into text
             config: remarkNodetoText(node),
             xkcdType,
-            w,
-            h,
-            ...attributes
+            ...node.attributes
           }
         };
 


### PR DESCRIPTION
`width` and `height` attributes were being converted to `w`/`h` for no benefit, as both forms work in Chakra-UI.

The rehype-sanitize schema still contains `w` and `h` since they are convenient shortcuts.