### PR TITLE
fix: Update Webhooks mapping

### DIFF
--- a/packages/backend/indices/iex-webhooks.json
+++ b/packages/backend/indices/iex-webhooks.json
@@ -2,217 +2,1406 @@
   "mappings": {
     "properties": {
       "action": {
-        "type": "text",
-        "fields": {
-          "keyword": {
-            "type": "keyword",
-            "ignore_above": 256
+        "type": "keyword",
+        "ignore_above": 256
+      },
+      "after": {
+        "type": "keyword",
+        "ignore_above": 256
+      },
+      "before": {
+        "type": "keyword",
+        "ignore_above": 256
+      },
+      "changes": {
+        "properties": {
+          "description": {
+            "properties": {
+              "from": {
+                "type": "text"
+              }
+            }
+          },
+          "permission": {
+            "properties": {
+              "from": {
+                "type": "text"
+              },
+              "to": {
+                "type": "text"
+              }
+            }
           }
         }
       },
-      "enterprise": {
+      "commits": {
         "properties": {
-          "avatar_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
+          "added": {
+            "type": "text"
+          },
+          "author": {
+            "properties": {
+              "email": {
+                "type": "text"
+              },
+              "name": {
+                "type": "text"
+              },
+              "username": {
+                "type": "text"
+              }
+            }
+          },
+          "committer": {
+            "properties": {
+              "email": {
+                "type": "text"
+              },
+              "name": {
+                "type": "text"
+              },
+              "username": {
+                "type": "text"
+              }
+            }
+          },
+          "distinct": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "text"
+          },
+          "message": {
+            "type": "text"
+          },
+          "modified": {
+            "type": "text"
+          },
+          "removed": {
+            "type": "text"
+          },
+          "timestamp": {
+            "type": "date"
+          },
+          "tree_id": {
+            "type": "text"
+          },
+          "url": {
+            "type": "text"
+          }
+        }
+      },
+      "compare": {
+        "type": "text"
+      },
+      "created": {
+        "type": "boolean"
+      },
+      "deleted": {
+        "type": "boolean"
+      },
+      "description": {
+        "type": "text"
+      },
+      "forced": {
+        "type": "boolean"
+      },
+      "head_commit": {
+        "properties": {
+          "added": {
+            "type": "text"
+          },
+          "author": {
+            "properties": {
+              "email": {
+                "type": "text"
+              },
+              "name": {
+                "type": "text"
+              },
+              "username": {
+                "type": "text"
+              }
+            }
+          },
+          "committer": {
+            "properties": {
+              "email": {
+                "type": "text"
+              },
+              "name": {
+                "type": "text"
+              },
+              "username": {
+                "type": "text"
+              }
+            }
+          },
+          "distinct": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "text"
+          },
+          "message": {
+            "type": "text"
+          },
+          "modified": {
+            "type": "text"
+          },
+          "removed": {
+            "type": "text"
+          },
+          "timestamp": {
+            "type": "date"
+          },
+          "tree_id": {
+            "type": "text"
+          },
+          "url": {
+            "type": "text"
+          }
+        }
+      },
+      "headers": {
+        "properties": {
+          "accept": {
+            "type": "text"
+          },
+          "accept-encoding": {
+            "type": "text"
+          },
+          "content-length": {
+            "type": "text"
+          },
+          "content-type": {
+            "type": "text"
+          },
+          "host": {
+            "type": "text"
+          },
+          "user-agent": {
+            "type": "text"
+          },
+          "x-amzn-trace-id": {
+            "type": "text"
+          },
+          "x-forwarded-for": {
+            "type": "text"
+          },
+          "x-forwarded-host": {
+            "type": "text"
+          },
+          "x-forwarded-port": {
+            "type": "text"
+          },
+          "x-forwarded-proto": {
+            "type": "text"
+          },
+          "x-forwarded-server": {
+            "type": "text"
+          },
+          "x-github-delivery": {
+            "type": "text"
+          },
+          "x-github-enterprise-host": {
+            "type": "text"
+          },
+          "x-github-enterprise-version": {
+            "type": "text"
+          },
+          "x-github-event": {
+            "type": "text"
+          },
+          "x-github-hook-id": {
+            "type": "text"
+          },
+          "x-github-hook-installation-target-id": {
+            "type": "text"
+          },
+          "x-github-hook-installation-target-type": {
+            "type": "text"
+          },
+          "x-real-ip": {
+            "type": "text"
+          }
+        }
+      },
+      "hook": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "config": {
+            "properties": {
+              "content_type": {
                 "type": "keyword",
                 "ignore_above": 256
+              },
+              "insecure_ssl": {
+                "type": "keyword",
+                "ignore_above": 256
+              },
+              "url": {
+                "type": "text"
               }
             }
           },
           "created_at": {
             "type": "date"
           },
-          "html_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          "events": {
+            "type": "text"
           },
           "id": {
             "type": "long"
           },
+          "last_response": {
+            "properties": {
+              "status": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
           "name": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
-          "node_id": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          "ping_url": {
+            "type": "text"
           },
-          "slug": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          "test_url": {
+            "type": "text"
+          },
+          "type": {
+            "type": "keyword",
+            "ignore_above": 256
           },
           "updated_at": {
             "type": "date"
+          },
+          "url": {
+            "type": "text"
           }
         }
+      },
+      "hook_id": {
+        "type": "long"
+      },
+      "member": {
+        "properties": {
+          "avatar_url": {
+            "type": "text"
+          },
+          "events_url": {
+            "type": "text"
+          },
+          "followers_url": {
+            "type": "text"
+          },
+          "following_url": {
+            "type": "text"
+          },
+          "gists_url": {
+            "type": "text"
+          },
+          "gravatar_id": {
+            "type": "text"
+          },
+          "html_url": {
+            "type": "text"
+          },
+          "id": {
+            "type": "long"
+          },
+          "ldap_dn": {
+            "type": "text"
+          },
+          "login": {
+            "type": "text"
+          },
+          "node_id": {
+            "type": "text"
+          },
+          "organizations_url": {
+            "type": "text"
+          },
+          "received_events_url": {
+            "type": "text"
+          },
+          "repos_url": {
+            "type": "text"
+          },
+          "site_admin": {
+            "type": "boolean"
+          },
+          "starred_url": {
+            "type": "text"
+          },
+          "subscriptions_url": {
+            "type": "text"
+          },
+          "type": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "url": {
+            "type": "text"
+          }
+        }
+      },
+      "organization": {
+        "properties": {
+          "avatar_url": {
+            "type": "text"
+          },
+          "description": {
+            "type": "text"
+          },
+          "events_url": {
+            "type": "text"
+          },
+          "hooks_url": {
+            "type": "text"
+          },
+          "id": {
+            "type": "long"
+          },
+          "issues_url": {
+            "type": "text"
+          },
+          "login": {
+            "type": "text"
+          },
+          "members_url": {
+            "type": "text"
+          },
+          "node_id": {
+            "type": "text"
+          },
+          "public_members_url": {
+            "type": "text"
+          },
+          "repos_url": {
+            "type": "text"
+          },
+          "url": {
+            "type": "text"
+          }
+        }
+      },
+      "pull_request": {
+        "properties": {
+          "_links": {
+            "properties": {
+              "comments": {
+                "properties": {
+                  "href": {
+                    "type": "text"
+                  }
+                }
+              },
+              "commits": {
+                "properties": {
+                  "href": {
+                    "type": "text"
+                  }
+                }
+              },
+              "html": {
+                "properties": {
+                  "href": {
+                    "type": "text"
+                  }
+                }
+              },
+              "issue": {
+                "properties": {
+                  "href": {
+                    "type": "text"
+                  }
+                }
+              },
+              "review_comment": {
+                "properties": {
+                  "href": {
+                    "type": "text"
+                  }
+                }
+              },
+              "review_comments": {
+                "properties": {
+                  "href": {
+                    "type": "text"
+                  }
+                }
+              },
+              "self": {
+                "properties": {
+                  "href": {
+                    "type": "text"
+                  }
+                }
+              },
+              "statuses": {
+                "properties": {
+                  "href": {
+                    "type": "text"
+                  }
+                }
+              }
+            }
+          },
+          "additions": {
+            "type": "long"
+          },
+          "author_association": {
+            "type": "text"
+          },
+          "base": {
+            "properties": {
+              "label": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "ref": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "repo": {
+                "properties": {
+                  "allow_merge_commit": {
+                    "type": "boolean"
+                  },
+                  "allow_rebase_merge": {
+                    "type": "boolean"
+                  },
+                  "allow_squash_merge": {
+                    "type": "boolean"
+                  },
+                  "archive_url": {
+                    "type": "text"
+                  },
+                  "archived": {
+                    "type": "boolean"
+                  },
+                  "assignees_url": {
+                    "type": "text"
+                  },
+                  "blobs_url": {
+                    "type": "text"
+                  },
+                  "branches_url": {
+                    "type": "text"
+                  },
+                  "clone_url": {
+                    "type": "text"
+                  },
+                  "collaborators_url": {
+                    "type": "text"
+                  },
+                  "comments_url": {
+                    "type": "text"
+                  },
+                  "commits_url": {
+                    "type": "text"
+                  },
+                  "compare_url": {
+                    "type": "text"
+                  },
+                  "contents_url": {
+                    "type": "text"
+                  },
+                  "contributors_url": {
+                    "type": "text"
+                  },
+                  "created_at": {
+                    "type": "date"
+                  },
+                  "default_branch": {
+                    "type": "text"
+                  },
+                  "delete_branch_on_merge": {
+                    "type": "boolean"
+                  },
+                  "deployments_url": {
+                    "type": "text"
+                  },
+                  "description": {
+                    "type": "text"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "downloads_url": {
+                    "type": "text"
+                  },
+                  "events_url": {
+                    "type": "text"
+                  },
+                  "fork": {
+                    "type": "boolean"
+                  },
+                  "forks": {
+                    "type": "long"
+                  },
+                  "forks_count": {
+                    "type": "long"
+                  },
+                  "forks_url": {
+                    "type": "text"
+                  },
+                  "full_name": {
+                    "type": "text"
+                  },
+                  "git_commits_url": {
+                    "type": "text"
+                  },
+                  "git_refs_url": {
+                    "type": "text"
+                  },
+                  "git_tags_url": {
+                    "type": "text"
+                  },
+                  "git_url": {
+                    "type": "text"
+                  },
+                  "has_downloads": {
+                    "type": "boolean"
+                  },
+                  "has_issues": {
+                    "type": "boolean"
+                  },
+                  "has_pages": {
+                    "type": "boolean"
+                  },
+                  "has_projects": {
+                    "type": "boolean"
+                  },
+                  "has_wiki": {
+                    "type": "boolean"
+                  },
+                  "hooks_url": {
+                    "type": "text"
+                  },
+                  "html_url": {
+                    "type": "text"
+                  },
+                  "id": {
+                    "type": "long"
+                  },
+                  "issue_comment_url": {
+                    "type": "text"
+                  },
+                  "issue_events_url": {
+                    "type": "text"
+                  },
+                  "issues_url": {
+                    "type": "text"
+                  },
+                  "keys_url": {
+                    "type": "text"
+                  },
+                  "labels_url": {
+                    "type": "text"
+                  },
+                  "language": {
+                    "type": "text"
+                  },
+                  "languages_url": {
+                    "type": "text"
+                  },
+                  "merges_url": {
+                    "type": "text"
+                  },
+                  "milestones_url": {
+                    "type": "text"
+                  },
+                  "name": {
+                    "type": "text"
+                  },
+                  "node_id": {
+                    "type": "text"
+                  },
+                  "notifications_url": {
+                    "type": "text"
+                  },
+                  "open_issues": {
+                    "type": "long"
+                  },
+                  "open_issues_count": {
+                    "type": "long"
+                  },
+                  "owner": {
+                    "properties": {
+                      "avatar_url": {
+                        "type": "text"
+                      },
+                      "events_url": {
+                        "type": "text"
+                      },
+                      "followers_url": {
+                        "type": "text"
+                      },
+                      "following_url": {
+                        "type": "text"
+                      },
+                      "gists_url": {
+                        "type": "text"
+                      },
+                      "gravatar_id": {
+                        "type": "text"
+                      },
+                      "html_url": {
+                        "type": "text"
+                      },
+                      "id": {
+                        "type": "long"
+                      },
+                      "login": {
+                        "type": "text"
+                      },
+                      "node_id": {
+                        "type": "text"
+                      },
+                      "organizations_url": {
+                        "type": "text"
+                      },
+                      "received_events_url": {
+                        "type": "text"
+                      },
+                      "repos_url": {
+                        "type": "text"
+                      },
+                      "site_admin": {
+                        "type": "boolean"
+                      },
+                      "starred_url": {
+                        "type": "text"
+                      },
+                      "subscriptions_url": {
+                        "type": "text"
+                      },
+                      "type": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      },
+                      "url": {
+                        "type": "text"
+                      }
+                    }
+                  },
+                  "private": {
+                    "type": "boolean"
+                  },
+                  "pulls_url": {
+                    "type": "text"
+                  },
+                  "pushed_at": {
+                    "type": "date"
+                  },
+                  "releases_url": {
+                    "type": "text"
+                  },
+                  "size": {
+                    "type": "long"
+                  },
+                  "ssh_url": {
+                    "type": "text"
+                  },
+                  "stargazers_count": {
+                    "type": "long"
+                  },
+                  "stargazers_url": {
+                    "type": "text"
+                  },
+                  "statuses_url": {
+                    "type": "text"
+                  },
+                  "subscribers_url": {
+                    "type": "text"
+                  },
+                  "subscription_url": {
+                    "type": "text"
+                  },
+                  "svn_url": {
+                    "type": "text"
+                  },
+                  "tags_url": {
+                    "type": "text"
+                  },
+                  "teams_url": {
+                    "type": "text"
+                  },
+                  "trees_url": {
+                    "type": "text"
+                  },
+                  "updated_at": {
+                    "type": "date"
+                  },
+                  "url": {
+                    "type": "text"
+                  },
+                  "watchers": {
+                    "type": "long"
+                  },
+                  "watchers_count": {
+                    "type": "long"
+                  }
+                }
+              },
+              "sha": {
+                "type": "text"
+              },
+              "user": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "text"
+                  },
+                  "events_url": {
+                    "type": "text"
+                  },
+                  "followers_url": {
+                    "type": "text"
+                  },
+                  "following_url": {
+                    "type": "text"
+                  },
+                  "gists_url": {
+                    "type": "text"
+                  },
+                  "gravatar_id": {
+                    "type": "text"
+                  },
+                  "html_url": {
+                    "type": "text"
+                  },
+                  "id": {
+                    "type": "long"
+                  },
+                  "login": {
+                    "type": "text"
+                  },
+                  "node_id": {
+                    "type": "text"
+                  },
+                  "organizations_url": {
+                    "type": "text"
+                  },
+                  "received_events_url": {
+                    "type": "text"
+                  },
+                  "repos_url": {
+                    "type": "text"
+                  },
+                  "site_admin": {
+                    "type": "boolean"
+                  },
+                  "starred_url": {
+                    "type": "text"
+                  },
+                  "subscriptions_url": {
+                    "type": "text"
+                  },
+                  "type": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  },
+                  "url": {
+                    "type": "text"
+                  }
+                }
+              }
+            }
+          },
+          "body": {
+            "type": "text"
+          },
+          "changed_files": {
+            "type": "long"
+          },
+          "comments": {
+            "type": "long"
+          },
+          "comments_url": {
+            "type": "text"
+          },
+          "commits": {
+            "type": "long"
+          },
+          "commits_url": {
+            "type": "text"
+          },
+          "created_at": {
+            "type": "date"
+          },
+          "deletions": {
+            "type": "long"
+          },
+          "diff_url": {
+            "type": "text"
+          },
+          "draft": {
+            "type": "boolean"
+          },
+          "head": {
+            "properties": {
+              "label": {
+                "type": "text"
+              },
+              "ref": {
+                "type": "text"
+              },
+              "repo": {
+                "properties": {
+                  "allow_merge_commit": {
+                    "type": "boolean"
+                  },
+                  "allow_rebase_merge": {
+                    "type": "boolean"
+                  },
+                  "allow_squash_merge": {
+                    "type": "boolean"
+                  },
+                  "archive_url": {
+                    "type": "text"
+                  },
+                  "archived": {
+                    "type": "boolean"
+                  },
+                  "assignees_url": {
+                    "type": "text"
+                  },
+                  "blobs_url": {
+                    "type": "text"
+                  },
+                  "branches_url": {
+                    "type": "text"
+                  },
+                  "clone_url": {
+                    "type": "text"
+                  },
+                  "collaborators_url": {
+                    "type": "text"
+                  },
+                  "comments_url": {
+                    "type": "text"
+                  },
+                  "commits_url": {
+                    "type": "text"
+                  },
+                  "compare_url": {
+                    "type": "text"
+                  },
+                  "contents_url": {
+                    "type": "text"
+                  },
+                  "contributors_url": {
+                    "type": "text"
+                  },
+                  "created_at": {
+                    "type": "date"
+                  },
+                  "default_branch": {
+                    "type": "text"
+                  },
+                  "delete_branch_on_merge": {
+                    "type": "boolean"
+                  },
+                  "deployments_url": {
+                    "type": "text"
+                  },
+                  "description": {
+                    "type": "text"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "downloads_url": {
+                    "type": "text"
+                  },
+                  "events_url": {
+                    "type": "text"
+                  },
+                  "fork": {
+                    "type": "boolean"
+                  },
+                  "forks": {
+                    "type": "long"
+                  },
+                  "forks_count": {
+                    "type": "long"
+                  },
+                  "forks_url": {
+                    "type": "text"
+                  },
+                  "full_name": {
+                    "type": "text"
+                  },
+                  "git_commits_url": {
+                    "type": "text"
+                  },
+                  "git_refs_url": {
+                    "type": "text"
+                  },
+                  "git_tags_url": {
+                    "type": "text"
+                  },
+                  "git_url": {
+                    "type": "text"
+                  },
+                  "has_downloads": {
+                    "type": "boolean"
+                  },
+                  "has_issues": {
+                    "type": "boolean"
+                  },
+                  "has_pages": {
+                    "type": "boolean"
+                  },
+                  "has_projects": {
+                    "type": "boolean"
+                  },
+                  "has_wiki": {
+                    "type": "boolean"
+                  },
+                  "hooks_url": {
+                    "type": "text"
+                  },
+                  "html_url": {
+                    "type": "text"
+                  },
+                  "id": {
+                    "type": "long"
+                  },
+                  "issue_comment_url": {
+                    "type": "text"
+                  },
+                  "issue_events_url": {
+                    "type": "text"
+                  },
+                  "issues_url": {
+                    "type": "text"
+                  },
+                  "keys_url": {
+                    "type": "text"
+                  },
+                  "labels_url": {
+                    "type": "text"
+                  },
+                  "language": {
+                    "type": "text"
+                  },
+                  "languages_url": {
+                    "type": "text"
+                  },
+                  "merges_url": {
+                    "type": "text"
+                  },
+                  "milestones_url": {
+                    "type": "text"
+                  },
+                  "name": {
+                    "type": "text"
+                  },
+                  "node_id": {
+                    "type": "text"
+                  },
+                  "notifications_url": {
+                    "type": "text"
+                  },
+                  "open_issues": {
+                    "type": "long"
+                  },
+                  "open_issues_count": {
+                    "type": "long"
+                  },
+                  "owner": {
+                    "properties": {
+                      "avatar_url": {
+                        "type": "text"
+                      },
+                      "events_url": {
+                        "type": "text"
+                      },
+                      "followers_url": {
+                        "type": "text"
+                      },
+                      "following_url": {
+                        "type": "text"
+                      },
+                      "gists_url": {
+                        "type": "text"
+                      },
+                      "gravatar_id": {
+                        "type": "text"
+                      },
+                      "html_url": {
+                        "type": "text"
+                      },
+                      "id": {
+                        "type": "long"
+                      },
+                      "login": {
+                        "type": "text"
+                      },
+                      "node_id": {
+                        "type": "text"
+                      },
+                      "organizations_url": {
+                        "type": "text"
+                      },
+                      "received_events_url": {
+                        "type": "text"
+                      },
+                      "repos_url": {
+                        "type": "text"
+                      },
+                      "site_admin": {
+                        "type": "boolean"
+                      },
+                      "starred_url": {
+                        "type": "text"
+                      },
+                      "subscriptions_url": {
+                        "type": "text"
+                      },
+                      "type": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      },
+                      "url": {
+                        "type": "text"
+                      }
+                    }
+                  },
+                  "private": {
+                    "type": "boolean"
+                  },
+                  "pulls_url": {
+                    "type": "text"
+                  },
+                  "pushed_at": {
+                    "type": "date"
+                  },
+                  "releases_url": {
+                    "type": "text"
+                  },
+                  "size": {
+                    "type": "long"
+                  },
+                  "ssh_url": {
+                    "type": "text"
+                  },
+                  "stargazers_count": {
+                    "type": "long"
+                  },
+                  "stargazers_url": {
+                    "type": "text"
+                  },
+                  "statuses_url": {
+                    "type": "text"
+                  },
+                  "subscribers_url": {
+                    "type": "text"
+                  },
+                  "subscription_url": {
+                    "type": "text"
+                  },
+                  "svn_url": {
+                    "type": "text"
+                  },
+                  "tags_url": {
+                    "type": "text"
+                  },
+                  "teams_url": {
+                    "type": "text"
+                  },
+                  "trees_url": {
+                    "type": "text"
+                  },
+                  "updated_at": {
+                    "type": "date"
+                  },
+                  "url": {
+                    "type": "text"
+                  },
+                  "watchers": {
+                    "type": "long"
+                  },
+                  "watchers_count": {
+                    "type": "long"
+                  }
+                }
+              },
+              "sha": {
+                "type": "text"
+              },
+              "user": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "text"
+                  },
+                  "events_url": {
+                    "type": "text"
+                  },
+                  "followers_url": {
+                    "type": "text"
+                  },
+                  "following_url": {
+                    "type": "text"
+                  },
+                  "gists_url": {
+                    "type": "text"
+                  },
+                  "gravatar_id": {
+                    "type": "text"
+                  },
+                  "html_url": {
+                    "type": "text"
+                  },
+                  "id": {
+                    "type": "long"
+                  },
+                  "login": {
+                    "type": "text"
+                  },
+                  "node_id": {
+                    "type": "text"
+                  },
+                  "organizations_url": {
+                    "type": "text"
+                  },
+                  "received_events_url": {
+                    "type": "text"
+                  },
+                  "repos_url": {
+                    "type": "text"
+                  },
+                  "site_admin": {
+                    "type": "boolean"
+                  },
+                  "starred_url": {
+                    "type": "text"
+                  },
+                  "subscriptions_url": {
+                    "type": "text"
+                  },
+                  "type": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  },
+                  "url": {
+                    "type": "text"
+                  }
+                }
+              }
+            }
+          },
+          "html_url": {
+            "type": "text"
+          },
+          "id": {
+            "type": "long"
+          },
+          "issue_url": {
+            "type": "text"
+          },
+          "locked": {
+            "type": "boolean"
+          },
+          "maintainer_can_modify": {
+            "type": "boolean"
+          },
+          "mergeable_state": {
+            "type": "text"
+          },
+          "merged": {
+            "type": "boolean"
+          },
+          "node_id": {
+            "type": "text"
+          },
+          "number": {
+            "type": "long"
+          },
+          "patch_url": {
+            "type": "text"
+          },
+          "review_comment_url": {
+            "type": "text"
+          },
+          "review_comments": {
+            "type": "long"
+          },
+          "review_comments_url": {
+            "type": "text"
+          },
+          "state": {
+            "type": "text"
+          },
+          "statuses_url": {
+            "type": "text"
+          },
+          "title": {
+            "type": "text"
+          },
+          "updated_at": {
+            "type": "date"
+          },
+          "url": {
+            "type": "text"
+          },
+          "user": {
+            "properties": {
+              "avatar_url": {
+                "type": "text"
+              },
+              "events_url": {
+                "type": "text"
+              },
+              "followers_url": {
+                "type": "text"
+              },
+              "following_url": {
+                "type": "text"
+              },
+              "gists_url": {
+                "type": "text"
+              },
+              "gravatar_id": {
+                "type": "text"
+              },
+              "html_url": {
+                "type": "text"
+              },
+              "id": {
+                "type": "long"
+              },
+              "ldap_dn": {
+                "type": "text"
+              },
+              "login": {
+                "type": "text"
+              },
+              "node_id": {
+                "type": "text"
+              },
+              "organizations_url": {
+                "type": "text"
+              },
+              "received_events_url": {
+                "type": "text"
+              },
+              "repos_url": {
+                "type": "text"
+              },
+              "site_admin": {
+                "type": "boolean"
+              },
+              "starred_url": {
+                "type": "text"
+              },
+              "subscriptions_url": {
+                "type": "text"
+              },
+              "type": {
+                "type": "keyword",
+                "ignore_above": 256
+              },
+              "url": {
+                "type": "text"
+              }
+            }
+          }
+        }
+      },
+      "pusher": {
+        "properties": {
+          "email": {
+            "type": "text"
+          },
+          "name": {
+            "type": "text"
+          }
+        }
+      },
+      "pusher_type": {
+        "type": "keyword",
+        "ignore_above": 256
+      },
+      "ref": {
+        "type": "text"
+      },
+      "ref_type": {
+        "type": "keyword",
+        "ignore_above": 256
       },
       "repository": {
         "properties": {
           "archive_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "archived": {
             "type": "boolean"
           },
           "assignees_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "blobs_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "branches_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "clone_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "collaborators_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "comments_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "commits_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "compare_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "contents_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "contributors_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "created_at": {
             "type": "date"
           },
           "default_branch": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "deployments_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "disabled": {
             "type": "boolean"
           },
           "downloads_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "events_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "fork": {
             "type": "boolean"
@@ -224,58 +1413,22 @@
             "type": "long"
           },
           "forks_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "full_name": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "git_commits_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "git_refs_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "git_tags_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "git_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "has_downloads": {
             "type": "boolean"
@@ -293,124 +1446,46 @@
             "type": "boolean"
           },
           "hooks_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "html_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "id": {
             "type": "long"
           },
           "issue_comment_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "issue_events_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "issues_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "keys_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "labels_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "languages_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "merges_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "milestones_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "name": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "node_id": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "notifications_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "open_issues": {
             "type": "long"
@@ -421,163 +1496,62 @@
           "owner": {
             "properties": {
               "avatar_url": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "events_url": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "followers_url": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "following_url": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "gists_url": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "gravatar_id": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "html_url": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "id": {
                 "type": "long"
               },
               "ldap_dn": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "login": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "node_id": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "organizations_url": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "received_events_url": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "repos_url": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "site_admin": {
                 "type": "boolean"
               },
               "starred_url": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "subscriptions_url": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               },
               "type": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "keyword",
+                "ignore_above": 256
               },
               "url": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
+                "type": "text"
               }
             }
           },
@@ -585,293 +1559,58 @@
             "type": "boolean"
           },
           "pulls_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "pushed_at": {
             "type": "date"
           },
           "releases_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "size": {
             "type": "long"
           },
           "ssh_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "stargazers_count": {
             "type": "long"
           },
           "stargazers_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "statuses_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "subscribers_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "subscription_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "svn_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "tags_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "teams_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "trees_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "updated_at": {
             "type": "date"
           },
           "url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "watchers": {
             "type": "long"
           },
           "watchers_count": {
             "type": "long"
-          }
-        }
-      },
-      "sender": {
-        "properties": {
-          "avatar_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "events_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "followers_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "following_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "gists_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "gravatar_id": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "html_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "id": {
-            "type": "long"
-          },
-          "ldap_dn": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "login": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "node_id": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "organizations_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "received_events_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "repos_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "site_admin": {
-            "type": "boolean"
-          },
-          "starred_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "subscriptions_url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "type": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "url": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
           }
         }
       },

--- a/packages/backend/src/controllers/webhook.v1.ts
+++ b/packages/backend/src/controllers/webhook.v1.ts
@@ -39,6 +39,13 @@ export const hook = (req: Request, res: Response): void => {
     }
   };
 
+  // Remove some un-needed fields
+  delete webhook.enterprise;
+  delete webhook.master_branch;
+  delete webhook.sender;
+  delete webhook.team;
+  delete webhook.zen;
+
   // Track webhooks in Elasticsearch
   defaultElasticsearchClient.index({
     index: ElasticIndex.WEBHOOKS,


### PR DESCRIPTION
Updates the Elasticsearch mapping for the `iex-webhooks` index, and excluded some unneeded fields from being included.  This change reduces the number of fields created, because dynamic mapping creates unnecessary keyword mappings for text types.