### PR TITLE
refactor(lint): Frontend linting updates

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -46,6 +46,7 @@ rules:
         order: asc
         caseInsensitive: true
       newlines-between: always
+  unicorn/no-array-for-each: off
   unicorn/no-array-reduce: off
   unicorn/no-null: off
   unicorn/prefer-dom-node-text-content: off

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -32,7 +32,7 @@ rules:
       disallowTypeAnnotations: false
   '@typescript-eslint/no-explicit-any': off
   '@typescript-eslint/no-non-null-assertion': off
-  import/newline-after-import: off
+  import/newline-after-import: error
   import/order:
     - error
     - groups:

--- a/packages/backend/src/resolvers/admin.resolver.ts
+++ b/packages/backend/src/resolvers/admin.resolver.ts
@@ -25,6 +25,7 @@ import { DbInsight } from '../models/insight';
 import { Permission } from '../models/permission';
 import { User } from '../models/user';
 import { UserService } from '../services/user.service';
+
 @Service()
 @Resolver()
 export class AdminResolver {

--- a/packages/frontend/.eslintignore
+++ b/packages/frontend/.eslintignore
@@ -1,3 +1,5 @@
-node_modules
+coverage
 dist
+node_modules
+
 **/generated/graphql.ts

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -30,7 +30,6 @@ rules:
   unicorn/no-lonely-if: off
   unicorn/no-useless-undefined: off
   unicorn/prefer-export-from: off
-  unicorn/prefer-optional-catch-binding: off
   unicorn/prefer-spread: off
   unicorn/prefer-ternary:
     - warn

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -28,7 +28,6 @@ rules:
   unicorn/no-array-callback-reference: off
   unicorn/no-array-for-each: off
   unicorn/no-lonely-if: off
-  unicorn/no-new-array: off
   unicorn/no-useless-undefined: off
   unicorn/prefer-export-from: off
   unicorn/prefer-optional-catch-binding: off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -21,7 +21,6 @@ rules:
   '@typescript-eslint/no-unused-vars': off
   '@typescript-eslint/explicit-module-boundary-types': off
   no-console: ['off']
-  unicorn/better-regex: off
   unicorn/catch-error-name: off
   unicorn/consistent-destructuring: off
   unicorn/consistent-function-scoping: off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -33,7 +33,6 @@ rules:
   unicorn/no-new-array: off
   unicorn/no-useless-undefined: off
   unicorn/prefer-export-from: off
-  unicorn/prefer-number-properties: off
   unicorn/prefer-optional-catch-binding: off
   unicorn/prefer-regexp-test: off
   unicorn/prefer-spread: off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -29,7 +29,10 @@ rules:
   unicorn/no-array-for-each: off
   unicorn/no-lonely-if: off
   unicorn/no-useless-undefined: off
-  unicorn/prefer-export-from: off
+  unicorn/prefer-export-from:
+    - warn
+    -
+      ignoreUsedVariables: true
   unicorn/prefer-spread: off
   unicorn/prefer-ternary:
     - warn

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -4,19 +4,12 @@ parserOptions:
   sourceType: module
   warnOnUnsupportedTypeScriptVersion: false
 plugins:
-  - '@typescript-eslint'
   - jsx-a11y
 extends:
-  - eslint:recommended
-  - plugin:@typescript-eslint/recommended
-  - plugin:import/errors
-  - plugin:import/typescript
-  - plugin:prettier/recommended
   - plugin:jsx-a11y/recommended
   - plugin:react-hooks/recommended
 rules:
   '@typescript-eslint/explicit-function-return-type': off
-  '@typescript-eslint/no-explicit-any': off
   '@typescript-eslint/no-unused-vars': off
   '@typescript-eslint/explicit-module-boundary-types': off
   no-console: ['off']

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -34,7 +34,6 @@ rules:
   unicorn/no-new-array: off
   unicorn/no-useless-undefined: off
   unicorn/prefer-export-from: off
-  unicorn/prefer-math-trunc: off
   unicorn/prefer-number-properties: off
   unicorn/prefer-optional-catch-binding: off
   unicorn/prefer-regexp-test: off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -34,4 +34,6 @@ rules:
   unicorn/prefer-export-from: off
   unicorn/prefer-optional-catch-binding: off
   unicorn/prefer-spread: off
-  unicorn/prefer-ternary: off
+  unicorn/prefer-ternary:
+    - warn
+    - only-single-line

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -20,7 +20,6 @@ rules:
   '@typescript-eslint/no-explicit-any': off
   '@typescript-eslint/no-unused-vars': off
   '@typescript-eslint/explicit-module-boundary-types': off
-  import/newline-after-import: off
   no-console: ['off']
   unicorn/better-regex: off
   unicorn/catch-error-name: off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -34,7 +34,6 @@ rules:
   unicorn/no-useless-undefined: off
   unicorn/prefer-export-from: off
   unicorn/prefer-optional-catch-binding: off
-  unicorn/prefer-regexp-test: off
   unicorn/prefer-spread: off
   unicorn/prefer-string-starts-ends-with: off
   unicorn/prefer-ternary: off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -15,7 +15,6 @@ extends:
   - plugin:jsx-a11y/recommended
   - plugin:react-hooks/recommended
 rules:
-  '@typescript-eslint/consistent-type-imports': off
   '@typescript-eslint/explicit-function-return-type': off
   '@typescript-eslint/no-explicit-any': off
   '@typescript-eslint/no-unused-vars': off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -35,5 +35,4 @@ rules:
   unicorn/prefer-export-from: off
   unicorn/prefer-optional-catch-binding: off
   unicorn/prefer-spread: off
-  unicorn/prefer-string-starts-ends-with: off
   unicorn/prefer-ternary: off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -39,6 +39,5 @@ rules:
   unicorn/prefer-optional-catch-binding: off
   unicorn/prefer-regexp-test: off
   unicorn/prefer-spread: off
-  unicorn/prefer-string-slice: off
   unicorn/prefer-string-starts-ends-with: off
   unicorn/prefer-ternary: off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -24,7 +24,6 @@ rules:
   unicorn/catch-error-name: off
   unicorn/consistent-destructuring: off
   unicorn/consistent-function-scoping: off
-  unicorn/explicit-length-check: off
   unicorn/filename-case: off
   unicorn/no-array-callback-reference: off
   unicorn/no-array-for-each: off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -33,7 +33,6 @@ rules:
   unicorn/no-lonely-if: off
   unicorn/no-new-array: off
   unicorn/no-useless-undefined: off
-  unicorn/prefer-code-point: off
   unicorn/prefer-export-from: off
   unicorn/prefer-math-trunc: off
   unicorn/prefer-number-properties: off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -18,7 +18,6 @@ rules:
   unicorn/consistent-function-scoping: off
   unicorn/filename-case: off
   unicorn/no-array-callback-reference: off
-  unicorn/no-array-for-each: off
   unicorn/no-lonely-if: off
   unicorn/no-useless-undefined: off
   unicorn/prefer-export-from:

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -27,7 +27,6 @@ rules:
   unicorn/consistent-function-scoping: off
   unicorn/explicit-length-check: off
   unicorn/filename-case: off
-  unicorn/new-for-builtins: off
   unicorn/no-array-callback-reference: off
   unicorn/no-array-for-each: off
   unicorn/no-lonely-if: off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -21,7 +21,6 @@ rules:
   '@typescript-eslint/no-unused-vars': off
   '@typescript-eslint/explicit-module-boundary-types': off
   no-console: ['off']
-  unicorn/catch-error-name: off
   unicorn/consistent-destructuring: off
   unicorn/consistent-function-scoping: off
   unicorn/filename-case: off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -12,6 +12,7 @@ rules:
   '@typescript-eslint/explicit-function-return-type': off
   '@typescript-eslint/no-unused-vars': off
   '@typescript-eslint/explicit-module-boundary-types': off
+  '@typescript-eslint/no-non-null-assertion': error
   no-console: ['off']
   unicorn/consistent-destructuring: off
   unicorn/consistent-function-scoping: off

--- a/packages/frontend/.eslintrc.yml
+++ b/packages/frontend/.eslintrc.yml
@@ -21,19 +21,6 @@ rules:
   '@typescript-eslint/no-unused-vars': off
   '@typescript-eslint/explicit-module-boundary-types': off
   import/newline-after-import: off
-  import/order:
-    - off
-    - groups:
-        - builtin
-        - external
-        - internal
-        - parent
-        - sibling
-        - index
-      alphabetize:
-        order: asc
-        caseInsensitive: true
-      newlines-between: always
   no-console: ['off']
   unicorn/better-regex: off
   unicorn/catch-error-name: off

--- a/packages/frontend/src/components/activity-list/activity-list.tsx
+++ b/packages/frontend/src/components/activity-list/activity-list.tsx
@@ -18,7 +18,7 @@ import { Flex, Skeleton, StackDivider, Text, useToast, VStack } from '@chakra-ui
 import InfiniteScroll from 'react-infinite-scroller';
 
 import { Alert } from '../../components/alert/alert';
-import { ActivityConnection } from '../../models/generated/graphql';
+import type { ActivityConnection } from '../../models/generated/graphql';
 import { useLikedBy } from '../../shared/useLikedBy';
 import { ActivityView } from '../activity-view/activity-view';
 

--- a/packages/frontend/src/components/activity-list/components/activity-list-skeleton/activity-list-skeleton.tsx
+++ b/packages/frontend/src/components/activity-list/components/activity-list-skeleton/activity-list-skeleton.tsx
@@ -20,20 +20,22 @@ const widthArray = ['50%', '25%', '80%', '40%', '66%'];
 export const ActivityListSkeleton = ({ count = 3 }) => {
   return (
     <VStack align="stretch" divider={<StackDivider borderColor="snowstorm.300" />}>
-      {new Array(count).fill(1).map((value, index) => (
-        <VStack key={`activity-icon-skeleton-${index}`} align="stretch">
-          <HStack>
-            <Skeleton boxSize="1.5rem" />
-            <Box flexGrow={2}>
-              <Skeleton height="1.5rem" width={widthArray[index % 5]} />
+      {Array.from({ length: count })
+        .fill(1)
+        .map((value, index) => (
+          <VStack key={`activity-icon-skeleton-${index}`} align="stretch">
+            <HStack>
+              <Skeleton boxSize="1.5rem" />
+              <Box flexGrow={2}>
+                <Skeleton height="1.5rem" width={widthArray[index % 5]} />
+              </Box>
+              <Skeleton height="1.5rem" width="4.5rem" />
+            </HStack>
+            <Box>
+              <Skeleton ml="2rem" height="2.5rem" width="auto" />
             </Box>
-            <Skeleton height="1.5rem" width="4.5rem" />
-          </HStack>
-          <Box>
-            <Skeleton ml="2rem" height="2.5rem" width="auto" />
-          </Box>
-        </VStack>
-      ))}
+          </VStack>
+        ))}
     </VStack>
   );
 };

--- a/packages/frontend/src/components/activity-list/fetch-activity-list.tsx
+++ b/packages/frontend/src/components/activity-list/fetch-activity-list.tsx
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-import { BoxProps } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
 import { memo } from 'react';
 
-import { Sort } from '../../models/generated/graphql';
+import type { Sort } from '../../models/generated/graphql';
 import { useActivities } from '../../shared/useActivities';
 import { Alert } from '../alert/alert';
 
-import { ActivityList, ActivityListProps } from './activity-list';
+import type { ActivityListProps } from './activity-list';
+import { ActivityList } from './activity-list';
 
 type Props = Omit<ActivityListProps, 'activityConnection' | 'onLikeActivity'> & {
   query?: string;

--- a/packages/frontend/src/components/activity-view/activity-view.tsx
+++ b/packages/frontend/src/components/activity-view/activity-view.tsx
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-import { BoxProps } from '@chakra-ui/layout';
+import type { BoxProps } from '@chakra-ui/layout';
 import { Badge, Box, Flex, HStack, Icon, Text, Tooltip, VStack } from '@chakra-ui/react';
 import { useState } from 'react';
 
-import {
+import type {
   Activity,
   ActivityEdge,
-  ActivityType,
   CommentActivityDetails,
   InsightActivityDetails,
   InsightCollaboratorActivityDetails,
   NewsActivityDetails,
   User
 } from '../../models/generated/graphql';
+import { ActivityType } from '../../models/generated/graphql';
 import { formatDateIntl, formatRelativeIntl } from '../../shared/date-utils';
 import { iconFactory } from '../../shared/icon-factory';
 import { BlockQuote } from '../blockquote/blockquote';

--- a/packages/frontend/src/components/alert/alert.tsx
+++ b/packages/frontend/src/components/alert/alert.tsx
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { Alert as ChakraAlert, AlertIcon, AlertStatus, As, BoxProps, Flex, Text } from '@chakra-ui/react';
+import type { AlertStatus, As, BoxProps } from '@chakra-ui/react';
+import { Alert as ChakraAlert, AlertIcon, Flex, Text } from '@chakra-ui/react';
 import startCase from 'lodash/startCase';
-import { ReactChild, ReactChildren } from 'react';
+import type { ReactChild, ReactChildren } from 'react';
 
 import { iconFactory } from '../../shared/icon-factory';
 

--- a/packages/frontend/src/components/alert/alert.tsx
+++ b/packages/frontend/src/components/alert/alert.tsx
@@ -35,11 +35,7 @@ interface Props {
 }
 
 function getMessage(i: StringOrMessage): string {
-  if (typeof i === 'string') {
-    return i;
-  } else {
-    return i.message;
-  }
+  return typeof i === 'string' ? i : i.message;
 }
 
 export const Alert = ({

--- a/packages/frontend/src/components/auth/auth-provider.tsx
+++ b/packages/frontend/src/components/auth/auth-provider.tsx
@@ -18,7 +18,7 @@ import { useSelector } from 'react-redux';
 import { Routes, Route } from 'react-router-dom';
 
 import { AuthErrorPage } from '../../pages/auth-error-page/auth-error-page';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 
 import { GitHubAuthProvider } from './github-auth-provider/github-auth-provider';
 import { OktaAuthProvider } from './okta-auth-provider/okta-auth-provider';

--- a/packages/frontend/src/components/auth/github-auth-provider/github-auth-provider.tsx
+++ b/packages/frontend/src/components/auth/github-auth-provider/github-auth-provider.tsx
@@ -18,7 +18,6 @@ import { Spinner, Text, VStack } from '@chakra-ui/react';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Routes, Route, useNavigate, useSearchParams, useLocation } from 'react-router-dom';
-
 import { gql } from 'urql';
 
 import type { RootState } from '../../../store/store';

--- a/packages/frontend/src/components/auth/github-auth-provider/github-auth-provider.tsx
+++ b/packages/frontend/src/components/auth/github-auth-provider/github-auth-provider.tsx
@@ -18,6 +18,7 @@ import { Spinner, Text, VStack } from '@chakra-ui/react';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Routes, Route, useNavigate, useSearchParams, useLocation } from 'react-router-dom';
+
 import { gql } from 'urql';
 
 import { RootState } from '../../../store/store';

--- a/packages/frontend/src/components/auth/github-auth-provider/github-auth-provider.tsx
+++ b/packages/frontend/src/components/auth/github-auth-provider/github-auth-provider.tsx
@@ -21,7 +21,7 @@ import { Routes, Route, useNavigate, useSearchParams, useLocation } from 'react-
 
 import { gql } from 'urql';
 
-import { RootState } from '../../../store/store';
+import type { RootState } from '../../../store/store';
 import { userSlice, login } from '../../../store/user.slice';
 import { urqlClient } from '../../../urql';
 

--- a/packages/frontend/src/components/auth/okta-auth-provider/okta-auth-provider.tsx
+++ b/packages/frontend/src/components/auth/okta-auth-provider/okta-auth-provider.tsx
@@ -21,7 +21,7 @@ import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Routes, Route, useNavigate } from 'react-router-dom';
 
-import { RootState } from '../../../store/store';
+import type { RootState } from '../../../store/store';
 import { userSlice, login } from '../../../store/user.slice';
 
 export const AUTH_CALLBACK_PATH = '/auth/callback';

--- a/packages/frontend/src/components/blockquote/blockquote.tsx
+++ b/packages/frontend/src/components/blockquote/blockquote.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Text, TextProps } from '@chakra-ui/react';
+import type { TextProps } from '@chakra-ui/react';
+import { Text } from '@chakra-ui/react';
 
 export const BlockQuote = ({ children, ...props }: { children: any } & TextProps) => {
   return (

--- a/packages/frontend/src/components/card/card.tsx
+++ b/packages/frontend/src/components/card/card.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, BoxProps, useColorModeValue } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Box, useColorModeValue } from '@chakra-ui/react';
 
 export const Card = (boxProps: BoxProps) => {
   return (

--- a/packages/frontend/src/components/code-editor/code-editor.tsx
+++ b/packages/frontend/src/components/code-editor/code-editor.tsx
@@ -66,7 +66,7 @@ export const CodeEditor = ({ contents, language, onContentsChange, readOnly = fa
       showPrintMargin={false}
       width="100%"
       minLines={30}
-      maxLines={Infinity}
+      maxLines={Number.POSITIVE_INFINITY}
       readOnly={readOnly}
       setOptions={{
         enableBasicAutocompletion: true,

--- a/packages/frontend/src/components/date-picker/date-picker.tsx
+++ b/packages/frontend/src/components/date-picker/date-picker.tsx
@@ -15,8 +15,9 @@
  */
 
 import { useColorMode } from '@chakra-ui/react';
-import { HTMLAttributes } from 'react';
-import ReactDatePicker, { ReactDatePickerProps } from 'react-datepicker';
+import type { HTMLAttributes } from 'react';
+import type { ReactDatePickerProps } from 'react-datepicker';
+import ReactDatePicker from 'react-datepicker';
 
 import 'react-datepicker/dist/react-datepicker.css';
 import './date-picker.css';

--- a/packages/frontend/src/components/date-range/date-range.tsx
+++ b/packages/frontend/src/components/date-range/date-range.tsx
@@ -73,11 +73,7 @@ function parseDate(dateString: string | undefined): Date | undefined {
   }
   const date = DateTime.fromISO(dateString);
 
-  if (date.isValid) {
-    return date.toJSDate();
-  } else {
-    return undefined;
-  }
+  return date.isValid ? date.toJSDate() : undefined;
 }
 
 const RelativeDateLink = ({ start, end, onChange, children }) => {

--- a/packages/frontend/src/components/date-range/date-range.tsx
+++ b/packages/frontend/src/components/date-range/date-range.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import type { BoxProps } from '@chakra-ui/react';
 import {
   Box,
-  BoxProps,
   Button,
   FormControl,
   FormLabel,

--- a/packages/frontend/src/components/delete-icon-button/delete-icon-button.tsx
+++ b/packages/frontend/src/components/delete-icon-button/delete-icon-button.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Tooltip, IconButton, IconButtonProps } from '@chakra-ui/react';
+import type { IconButtonProps } from '@chakra-ui/react';
+import { Tooltip, IconButton } from '@chakra-ui/react';
 
 import { iconFactoryAs } from '../../shared/icon-factory';
 

--- a/packages/frontend/src/components/external-link/external-link.tsx
+++ b/packages/frontend/src/components/external-link/external-link.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Icon, Link as ChakraLink, LinkProps } from '@chakra-ui/react';
+import type { LinkProps } from '@chakra-ui/react';
+import { Icon, Link as ChakraLink } from '@chakra-ui/react';
 
 import { iconFactory } from '../../shared/icon-factory';
 

--- a/packages/frontend/src/components/file-browser/file-browser.tsx
+++ b/packages/frontend/src/components/file-browser/file-browser.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import type { BoxProps } from '@chakra-ui/react';
 import {
   Badge,
   Box,
-  BoxProps,
   Button,
   Collapse,
   Editable,
@@ -33,9 +33,10 @@ import {
 } from '@chakra-ui/react';
 import { useState } from 'react';
 
-import { FileOrFolder, InsightFolder } from '../../models/file-tree';
+import type { FileOrFolder, InsightFolder } from '../../models/file-tree';
 import { fileIconFactoryAs } from '../../shared/file-icon-factory';
-import { InsightFileTree, isFolder } from '../../shared/file-tree';
+import type { InsightFileTree } from '../../shared/file-tree';
+import { isFolder } from '../../shared/file-tree';
 import { iconFactoryAs } from '../../shared/icon-factory';
 import { DeleteIconButton } from '../delete-icon-button/delete-icon-button';
 

--- a/packages/frontend/src/components/file-upload-area/file-upload-area.tsx
+++ b/packages/frontend/src/components/file-upload-area/file-upload-area.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, BoxProps } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Box } from '@chakra-ui/react';
 import { useDropzone } from 'react-dropzone';
 
 export const DROPZONE_ACCEPT_ALL_FILES = '';

--- a/packages/frontend/src/components/file-viewer/file-viewer.tsx
+++ b/packages/frontend/src/components/file-viewer/file-viewer.tsx
@@ -14,24 +14,15 @@
  * limitations under the License.
  */
 
-import {
-  Box,
-  BoxProps,
-  Flex,
-  HStack,
-  Icon,
-  IconButton,
-  Link,
-  Progress,
-  Spinner,
-  Tooltip,
-  VStack
-} from '@chakra-ui/react';
-import { ReactElement, useState } from 'react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Box, Flex, HStack, Icon, IconButton, Link, Progress, Spinner, Tooltip, VStack } from '@chakra-ui/react';
+import type { ReactElement } from 'react';
+import { useState } from 'react';
 import { Helmet } from 'react-helmet';
 
 import { Alert } from '../../components/alert/alert';
-import { Crumb, Crumbs } from '../../components/crumbs/crumbs';
+import type { Crumb } from '../../components/crumbs/crumbs';
+import { Crumbs } from '../../components/crumbs/crumbs';
 import { iconFactory, iconFactoryAs } from '../../shared/icon-factory';
 import { getMimeTypeDefinition, MIME_VIEWER } from '../../shared/mime-utils';
 import { getCompletePath } from '../../shared/url-utils';

--- a/packages/frontend/src/components/form-label/form-label.tsx
+++ b/packages/frontend/src/components/form-label/form-label.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { FormLabel as ChakraFormLabel, FormLabelProps } from '@chakra-ui/react';
+import type { FormLabelProps } from '@chakra-ui/react';
+import { FormLabel as ChakraFormLabel } from '@chakra-ui/react';
 
 interface Props {
   childre?: boolean;

--- a/packages/frontend/src/components/html-split-editor/html-split-editor.tsx
+++ b/packages/frontend/src/components/html-split-editor/html-split-editor.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Flex, FlexProps, IconButton, Tooltip, Box } from '@chakra-ui/react';
+import type { FlexProps } from '@chakra-ui/react';
+import { Flex, IconButton, Tooltip, Box } from '@chakra-ui/react';
 import { useEffect, useRef, useState } from 'react';
 
 import { iconFactoryAs } from '../../shared/icon-factory';

--- a/packages/frontend/src/components/icon-button-menu/icon-button-menu.tsx
+++ b/packages/frontend/src/components/icon-button-menu/icon-button-menu.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Box, IconButton, Icon, Menu, MenuButton, MenuList, Tooltip, forwardRef } from '@chakra-ui/react';
-import { ReactNode, ElementType } from 'react';
+import type { ReactNode, ElementType } from 'react';
 
 interface Props {
   'aria-label': string;

--- a/packages/frontend/src/components/iex-heading/iex-heading.tsx
+++ b/packages/frontend/src/components/iex-heading/iex-heading.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Heading, HeadingProps } from '@chakra-ui/react';
+import type { HeadingProps } from '@chakra-ui/react';
+import { Heading } from '@chakra-ui/react';
 
 interface Props {
   level: number;

--- a/packages/frontend/src/components/iex-menu-item/iex-menu-item.tsx
+++ b/packages/frontend/src/components/iex-menu-item/iex-menu-item.tsx
@@ -15,9 +15,9 @@
  */
 
 import { Box, Icon, Link, MenuItem, Square } from '@chakra-ui/react';
-import { MouseEventHandler, ReactChildren, ReactElement } from 'react';
-import { IconType } from 'react-icons';
-import { LinkProps } from 'react-router-dom';
+import type { MouseEventHandler, ReactChildren, ReactElement } from 'react';
+import type { IconType } from 'react-icons';
+import type { LinkProps } from 'react-router-dom';
 
 import { Link as RouterLink } from '../link/link';
 

--- a/packages/frontend/src/components/insight-collaborators-modal/insight-collaborators-modal.tsx
+++ b/packages/frontend/src/components/insight-collaborators-modal/insight-collaborators-modal.tsx
@@ -38,6 +38,7 @@ import {
 import { Controller, useForm } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 import Select from 'react-select';
+
 import { gql, useMutation, useQuery } from 'urql';
 
 import { iconFactoryAs } from '../../shared/icon-factory';

--- a/packages/frontend/src/components/insight-collaborators-modal/insight-collaborators-modal.tsx
+++ b/packages/frontend/src/components/insight-collaborators-modal/insight-collaborators-modal.tsx
@@ -38,7 +38,6 @@ import {
 import { Controller, useForm } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 import Select from 'react-select';
-
 import { gql, useMutation, useQuery } from 'urql';
 
 import { iconFactoryAs } from '../../shared/icon-factory';

--- a/packages/frontend/src/components/insight-collaborators-modal/insight-collaborators-modal.tsx
+++ b/packages/frontend/src/components/insight-collaborators-modal/insight-collaborators-modal.tsx
@@ -42,7 +42,7 @@ import Select from 'react-select';
 import { gql, useMutation, useQuery } from 'urql';
 
 import { iconFactoryAs } from '../../shared/icon-factory';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 import { Alert } from '../alert/alert';
 import { DeleteIconButton } from '../delete-icon-button/delete-icon-button';
 import { Link as RouterLink } from '../link/link';

--- a/packages/frontend/src/components/insight-connection-card/components/compact-insight-card/compact-insight-card.tsx
+++ b/packages/frontend/src/components/insight-connection-card/components/compact-insight-card/compact-insight-card.tsx
@@ -14,22 +14,13 @@
  * limitations under the License.
  */
 
-import {
-  Badge,
-  BoxProps,
-  Heading,
-  HStack,
-  LinkBox,
-  Tooltip,
-  useColorModeValue,
-  Wrap,
-  WrapItem
-} from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Badge, Heading, HStack, LinkBox, Tooltip, useColorModeValue, Wrap, WrapItem } from '@chakra-ui/react';
 
 import { InsightTag } from '../../../insight-tag/insight-tag';
 import { ItemTypeIcon } from '../../../item-type-icon/item-type-icon';
 import { LinkOverlay } from '../../../link-overlay/link-overlay';
-import { InsightConnectionCardProps } from '../../insight-connection-card';
+import type { InsightConnectionCardProps } from '../../insight-connection-card';
 import { InsightStats } from '../insight-stats/insight-stats';
 
 export const CompactInsightCard = ({ insightEdge, options, ...props }: InsightConnectionCardProps & BoxProps) => {

--- a/packages/frontend/src/components/insight-connection-card/components/default-insight-card/default-insight-card.tsx
+++ b/packages/frontend/src/components/insight-connection-card/components/default-insight-card/default-insight-card.tsx
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 
-import {
-  Badge,
-  BoxProps,
-  Flex,
-  Heading,
-  HStack,
-  LinkBox,
-  Text,
-  Tooltip,
-  VStack,
-  useColorModeValue
-} from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Badge, Flex, Heading, HStack, LinkBox, Text, Tooltip, VStack, useColorModeValue } from '@chakra-ui/react';
 import { DateTime } from 'luxon';
 
 import { formatDateIntl } from '../../../../shared/date-utils';
@@ -34,7 +24,7 @@ import { InsightTag } from '../../../insight-tag/insight-tag';
 import { ItemTypeIcon } from '../../../item-type-icon/item-type-icon';
 import { LinkOverlay } from '../../../link-overlay/link-overlay';
 import { UserTag } from '../../../user-tag/user-tag';
-import { InsightConnectionCardProps } from '../../insight-connection-card';
+import type { InsightConnectionCardProps } from '../../insight-connection-card';
 import { InsightStats } from '../insight-stats/insight-stats';
 
 export const DefaultInsightCard = ({ insightEdge, options, ...props }: InsightConnectionCardProps & BoxProps) => {

--- a/packages/frontend/src/components/insight-connection-card/components/insight-stats/insight-stats.tsx
+++ b/packages/frontend/src/components/insight-connection-card/components/insight-stats/insight-stats.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Badge, Box, HStack, Icon, StackProps, Tooltip } from '@chakra-ui/react';
+import type { StackProps } from '@chakra-ui/react';
+import { Badge, Box, HStack, Icon, Tooltip } from '@chakra-ui/react';
 
 import { LikedByTooltip } from '../../../../components/liked-by-tooltip/liked-by-tooltip';
 import { iconFactory } from '../../../../shared/icon-factory';

--- a/packages/frontend/src/components/insight-connection-card/components/square-insight-card/square-insight-card.tsx
+++ b/packages/frontend/src/components/insight-connection-card/components/square-insight-card/square-insight-card.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import type { BoxProps } from '@chakra-ui/react';
 import {
   Badge,
   Box,
-  BoxProps,
   Heading,
   HStack,
   LinkBox,
@@ -35,7 +35,7 @@ import { InsightTag } from '../../../insight-tag/insight-tag';
 import { ItemTypeIcon } from '../../../item-type-icon/item-type-icon';
 import { LinkOverlay } from '../../../link-overlay/link-overlay';
 import { UserTag } from '../../../user-tag/user-tag';
-import { InsightConnectionCardProps } from '../../insight-connection-card';
+import type { InsightConnectionCardProps } from '../../insight-connection-card';
 import { InsightStats } from '../insight-stats/insight-stats';
 
 export const SquareInsightCard = ({ insightEdge, options, ...props }: InsightConnectionCardProps & BoxProps) => {

--- a/packages/frontend/src/components/insight-connection-card/fetch-insight-connection-card.tsx
+++ b/packages/frontend/src/components/insight-connection-card/fetch-insight-connection-card.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import { BoxProps, Progress } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Progress } from '@chakra-ui/react';
 import { memo } from 'react';
 
 import { useInsight } from '../../shared/useInsight';
 import { Alert } from '../alert/alert';
-import { InsightConnectionCard, InsightConnectionCardProps } from '../insight-connection-card/insight-connection-card';
+import type { InsightConnectionCardProps } from '../insight-connection-card/insight-connection-card';
+import { InsightConnectionCard } from '../insight-connection-card/insight-connection-card';
 
 type Props = Omit<InsightConnectionCardProps, 'insightEdge'> & { fullName: string };
 

--- a/packages/frontend/src/components/insight-connection-card/insight-connection-card.tsx
+++ b/packages/frontend/src/components/insight-connection-card/insight-connection-card.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { BoxProps } from '@chakra-ui/layout';
+import type { BoxProps } from '@chakra-ui/layout';
 
-import { InsightEdge } from '../../models/generated/graphql';
-import { SearchOptions } from '../../store/search.slice';
+import type { InsightEdge } from '../../models/generated/graphql';
+import type { SearchOptions } from '../../store/search.slice';
 
 import { CompactInsightCard } from './components/compact-insight-card/compact-insight-card';
 import { DefaultInsightCard } from './components/default-insight-card/default-insight-card';

--- a/packages/frontend/src/components/insight-list/components/insight-list-skeleton/insight-list-skeleton.tsx
+++ b/packages/frontend/src/components/insight-list/components/insight-list-skeleton/insight-list-skeleton.tsx
@@ -29,13 +29,15 @@ export const InsightListSkeleton = ({ count = 3, options }) => {
           }
         }}
       >
-        {new Array(count * 2).fill(1).map((value, index) => (
-          <Skeleton
-            key={`search-results-skeleton-${index}`}
-            sx={{ aspectRatio: '1' }}
-            width={{ base: 'unset', sm: '16rem', md: '17rem', lg: '18rem', '2xl': '20rem' }}
-          />
-        ))}
+        {Array.from({ length: count * 2 })
+          .fill(1)
+          .map((value, index) => (
+            <Skeleton
+              key={`search-results-skeleton-${index}`}
+              sx={{ aspectRatio: '1' }}
+              width={{ base: 'unset', sm: '16rem', md: '17rem', lg: '18rem', '2xl': '20rem' }}
+            />
+          ))}
       </Wrap>
     );
   }
@@ -64,9 +66,11 @@ export const InsightListSkeleton = ({ count = 3, options }) => {
 
   return (
     <>
-      {new Array(count).fill(1).map((value, index) => (
-        <Skeleton key={`search-results-skeleton-${index}`} mb="1rem" {...layoutProps} />
-      ))}
+      {Array.from({ length: count })
+        .fill(1)
+        .map((value, index) => (
+          <Skeleton key={`search-results-skeleton-${index}`} mb="1rem" {...layoutProps} />
+        ))}
     </>
   );
 };

--- a/packages/frontend/src/components/insight-list/fetch-insight-list.tsx
+++ b/packages/frontend/src/components/insight-list/fetch-insight-list.tsx
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-import { BoxProps, Progress } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Progress } from '@chakra-ui/react';
 import { memo } from 'react';
 
-import { Sort } from '../../models/generated/graphql';
+import type { Sort } from '../../models/generated/graphql';
 import { useSearch } from '../../shared/useSearch';
 import { Alert } from '../alert/alert';
 
-import { InsightList, InsightListProps } from './insight-list';
+import type { InsightListProps } from './insight-list';
+import { InsightList } from './insight-list';
 
 type Props = Omit<InsightListProps, 'insightConnection'> & { query: string; sort?: Sort };
 

--- a/packages/frontend/src/components/insight-list/insight-list.tsx
+++ b/packages/frontend/src/components/insight-list/insight-list.tsx
@@ -18,8 +18,8 @@ import { Flex, Skeleton, Text, Wrap, WrapItem } from '@chakra-ui/react';
 import InfiniteScroll from 'react-infinite-scroller';
 
 import { Alert } from '../../components/alert/alert';
-import { InsightConnection } from '../../models/generated/graphql';
-import { SearchOptions } from '../../store/search.slice';
+import type { InsightConnection } from '../../models/generated/graphql';
+import type { SearchOptions } from '../../store/search.slice';
 import { InsightConnectionCard } from '../insight-connection-card/insight-connection-card';
 
 import { InsightListSkeleton } from './components/insight-list-skeleton/insight-list-skeleton';

--- a/packages/frontend/src/components/insight-tag/insight-tag.tsx
+++ b/packages/frontend/src/components/insight-tag/insight-tag.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Tag, TagLabel, TagProps } from '@chakra-ui/react';
+import type { TagProps } from '@chakra-ui/react';
+import { Tag, TagLabel } from '@chakra-ui/react';
 import { useDispatch } from 'react-redux';
 
 import { searchSlice } from '../../store/search.slice';

--- a/packages/frontend/src/components/item-type-icon/item-type-icon.tsx
+++ b/packages/frontend/src/components/item-type-icon/item-type-icon.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Icon, IconProps, Tooltip } from '@chakra-ui/react';
+import type { IconProps } from '@chakra-ui/react';
+import { Icon, Tooltip } from '@chakra-ui/react';
 import titleize from 'titleize';
 
 import { iconFactory } from '../../shared/icon-factory';

--- a/packages/frontend/src/components/like-button/like-button.tsx
+++ b/packages/frontend/src/components/like-button/like-button.tsx
@@ -18,7 +18,7 @@ import { useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { iconFactoryAs } from '../../shared/icon-factory';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 import { NumberIconButton } from '../number-icon-button/number-icon-button';
 
 interface Props {

--- a/packages/frontend/src/components/liked-by-tooltip/liked-by-tooltip.tsx
+++ b/packages/frontend/src/components/liked-by-tooltip/liked-by-tooltip.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { Placement } from '@chakra-ui/react';
 import {
   Avatar,
   Box,
@@ -27,7 +28,6 @@ import {
   ModalCloseButton,
   ModalBody,
   ModalFooter,
-  Placement,
   Popover,
   PopoverTrigger,
   PopoverContent,
@@ -39,10 +39,11 @@ import {
   useDisclosure,
   VStack
 } from '@chakra-ui/react';
-import { ReactNode, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { User } from '../../models/generated/graphql';
+import type { User } from '../../models/generated/graphql';
 import { Link as RouterLink } from '../link/link';
 import { OxfordComma } from '../oxford-comma/oxford-comma';
 

--- a/packages/frontend/src/components/link-overlay/link-overlay.tsx
+++ b/packages/frontend/src/components/link-overlay/link-overlay.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { LinkOverlay as ChakraLinkOverlay, LinkOverlayProps as ChakraLinkOverlayProps } from '@chakra-ui/react';
-import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
+import type { LinkOverlayProps as ChakraLinkOverlayProps } from '@chakra-ui/react';
+import { LinkOverlay as ChakraLinkOverlay } from '@chakra-ui/react';
+import type { LinkProps as RouterLinkProps } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 
 /**
  * Custom link overlay component that composes Chakra-UI presentation with React Router functionality

--- a/packages/frontend/src/components/link/link.tsx
+++ b/packages/frontend/src/components/link/link.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import { Link as ChakraLink, LinkProps as ChakraLinkProps } from '@chakra-ui/react';
+import type { LinkProps as ChakraLinkProps } from '@chakra-ui/react';
+import { Link as ChakraLink } from '@chakra-ui/react';
 import React, { forwardRef } from 'react';
-import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
+import type { LinkProps as RouterLinkProps } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 
 /**
  * Custom link component that composes Chakra-UI presentation with React Router functionality

--- a/packages/frontend/src/components/markdown-container/chakra-ui-renderer.tsx
+++ b/packages/frontend/src/components/markdown-container/chakra-ui-renderer.tsx
@@ -36,10 +36,10 @@ import {
   Thead,
   Tr
 } from '@chakra-ui/react';
-import { Components } from 'react-markdown';
+import type { Components } from 'react-markdown';
 import Zoom from 'react-medium-image-zoom';
 
-import { Sort } from '../../models/generated/graphql';
+import type { Sort } from '../../models/generated/graphql';
 import { destringObject } from '../../shared/destring';
 import { hashCode } from '../../shared/hash';
 import { iconFactory } from '../../shared/icon-factory';

--- a/packages/frontend/src/components/markdown-container/chakra-ui-renderer.tsx
+++ b/packages/frontend/src/components/markdown-container/chakra-ui-renderer.tsx
@@ -242,11 +242,11 @@ export const ChakraUIRenderer = (
       );
     },
     input: ({ node, children, ...props }) => {
-      if (props.type === 'checkbox') {
-        return <Checkbox isChecked={props.checked} isReadOnly mr="0.5rem" {...(props as any)} />;
-      } else {
-        return <Input {...(props as any)}>{children}</Input>;
-      }
+      return props.type === 'checkbox' ? (
+        <Checkbox isChecked={props.checked} isReadOnly mr="0.5rem" {...(props as any)} />
+      ) : (
+        <Input {...(props as any)}>{children}</Input>
+      );
     },
     table: ({ node, children, border, caption, width, ...props }: any) => {
       const defaultProps = { variant: 'simple', size: 'sm' };

--- a/packages/frontend/src/components/markdown-container/iex-markdown-schema.ts
+++ b/packages/frontend/src/components/markdown-container/iex-markdown-schema.ts
@@ -1,4 +1,4 @@
-import { Options } from 'rehype-sanitize';
+import type { Options } from 'rehype-sanitize';
 
 export const IexMarkdownSchema: Options = {
   strip: ['script'],

--- a/packages/frontend/src/components/markdown-container/markdown-container.tsx
+++ b/packages/frontend/src/components/markdown-container/markdown-container.tsx
@@ -28,13 +28,12 @@ import remarkDirective from 'remark-directive';
 import remarkEmoji from 'remark-emoji';
 import remarkGfm from 'remark-gfm';
 import remarkToc from 'remark-toc';
-import urljoin from 'url-join';
 
 import { remarkCodePlus } from '../../shared/remark/remark-code-plus';
 import { remarkIex } from '../../shared/remark/remark-iex';
 import { remarkIexLogo } from '../../shared/remark/remark-iex-logo';
 import { remarkMentions } from '../../shared/remark/remark-mentions';
-import { isHashUrl, isRelativeUrl } from '../../shared/url-utils';
+import { isHashUrl, isRelativeUrl, urljoin } from '../../shared/url-utils';
 import { pick } from '../../shared/utility';
 
 import { ChakraUIRenderer } from './chakra-ui-renderer';

--- a/packages/frontend/src/components/markdown-container/markdown-container.tsx
+++ b/packages/frontend/src/components/markdown-container/markdown-container.tsx
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
-import { Alert as ChakraAlert, AlertIcon, BoxProps, Box, Button, Flex, Text } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Alert as ChakraAlert, AlertIcon, Box, Button, Flex, Text } from '@chakra-ui/react';
 import isEqual from 'lodash/isEqual';
-import { memo, ReactElement, useCallback, useState } from 'react';
+import type { ReactElement } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import ReactMarkdown, { Components } from 'react-markdown';
-import { TransformLink } from 'react-markdown/lib/ast-to-react';
+import type { Components } from 'react-markdown';
+import ReactMarkdown from 'react-markdown';
+import type { TransformLink } from 'react-markdown/lib/ast-to-react';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize from 'rehype-sanitize';

--- a/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
+++ b/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
@@ -23,7 +23,7 @@ import AceEditor from 'react-ace';
 
 import { gql } from 'urql';
 
-import { UploadSingleFileMutation, UsersCompletionQuery } from '../../models/generated/graphql';
+import type { UploadSingleFileMutation, UsersCompletionQuery } from '../../models/generated/graphql';
 import { useDebounce } from '../../shared/useDebounce';
 import { urqlClient } from '../../urql';
 

--- a/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
+++ b/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
@@ -45,7 +45,7 @@ let emojiList: Record<string, unknown>[] | undefined = undefined;
 let userList: Record<string, unknown>[] | undefined = undefined;
 
 const emojiCompleter = {
-  identifierRegexps: [/[:]/],
+  identifierRegexps: [/:/],
   getCompletions: (editor, session, pos, prefix, callback) => {
     // Only trigger completions after an initial ":"
     if (prefix !== ':') {
@@ -80,7 +80,7 @@ const emojiCompleter = {
 };
 
 const mentionCompleter = {
-  identifierRegexps: [/[@]/],
+  identifierRegexps: [/@/],
   getCompletions: async (editor, session, pos, prefix, callback) => {
     // Only trigger completions after an initial "@"
     if (prefix !== '@') {

--- a/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
+++ b/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
@@ -20,6 +20,7 @@ import { nanoid } from 'nanoid';
 import { emoji } from 'node-emoji';
 import { useEffect, useRef, useState } from 'react';
 import AceEditor from 'react-ace';
+
 import { gql } from 'urql';
 
 import { UploadSingleFileMutation, UsersCompletionQuery } from '../../models/generated/graphql';

--- a/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
+++ b/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
@@ -20,7 +20,6 @@ import { nanoid } from 'nanoid';
 import { emoji } from 'node-emoji';
 import { useEffect, useRef, useState } from 'react';
 import AceEditor from 'react-ace';
-
 import { gql } from 'urql';
 
 import type { UploadSingleFileMutation, UsersCompletionQuery } from '../../models/generated/graphql';

--- a/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
+++ b/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
@@ -207,7 +207,7 @@ export const MarkdownEditor = ({ contents, onContentsChange, scrollSync, uploadF
       showPrintMargin={false}
       width="100%"
       minLines={30}
-      maxLines={scrollSync ? undefined : Infinity}
+      maxLines={scrollSync ? undefined : Number.POSITIVE_INFINITY}
       height={aceEditorHeight}
       setOptions={{
         scrollPastEnd: scrollSync,

--- a/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
+++ b/packages/frontend/src/components/markdown-editor/markdown-editor.tsx
@@ -143,7 +143,7 @@ export const MarkdownEditor = ({ contents, onContentsChange, scrollSync, uploadF
         // Set the proper image name by generating a random name if it has a default name (eg: 'image.png')
         // or add `<` and `>` characters to the name in case it contains any spaces
         const name = file.name.startsWith('image.')
-          ? file.name.replace('image', `pasted-${nanoid().substring(0, 6)}`)
+          ? file.name.replace('image', `pasted-${nanoid().slice(0, 6)}`)
           : file.name;
 
         // Insert the image with Markdown notation based on the current cursor position

--- a/packages/frontend/src/components/markdown-split-editor/markdown-split-editor.tsx
+++ b/packages/frontend/src/components/markdown-split-editor/markdown-split-editor.tsx
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+import type { FlexProps } from '@chakra-ui/react';
 import {
   Button,
   Code,
   Divider,
   Flex,
-  FlexProps,
   Icon,
   IconButton,
   Popover,
@@ -36,9 +36,10 @@ import {
   Checkbox,
   HStack
 } from '@chakra-ui/react';
-import { ReactNode, useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-import { UploadSingleFileMutation } from '../../models/generated/graphql';
+import type { UploadSingleFileMutation } from '../../models/generated/graphql';
 import { iconFactory, iconFactoryAs } from '../../shared/icon-factory';
 import { useDebounce } from '../../shared/useDebounce';
 import { Link } from '../link/link';

--- a/packages/frontend/src/components/number-icon-button/number-icon-button.tsx
+++ b/packages/frontend/src/components/number-icon-button/number-icon-button.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Badge, Box, Button, IconButton, Tooltip } from '@chakra-ui/react';
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 
 interface Props {
   color?: string;

--- a/packages/frontend/src/components/oxford-comma/oxford-comma.tsx
+++ b/packages/frontend/src/components/oxford-comma/oxford-comma.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Fragment, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import { Fragment } from 'react';
 
 interface Props {
   items: ReactNode[];

--- a/packages/frontend/src/components/renderers/code-renderer/code-renderer.tsx
+++ b/packages/frontend/src/components/renderers/code-renderer/code-renderer.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, BoxProps, Collapse, HStack, IconButton, Code, useClipboard, useDisclosure } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Box, Collapse, HStack, IconButton, Code, useClipboard, useDisclosure } from '@chakra-ui/react';
 import { memo, useEffect } from 'react';
 import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { nord } from 'react-syntax-highlighter/dist/esm/styles/prism';

--- a/packages/frontend/src/components/renderers/code-renderer/fetch-code-renderer.tsx
+++ b/packages/frontend/src/components/renderers/code-renderer/fetch-code-renderer.tsx
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-import { BoxProps, Progress } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Progress } from '@chakra-ui/react';
 import { memo } from 'react';
 
 import { filterContentByLines } from '../../../shared/lines';
 import { useFetch } from '../../../shared/useFetch';
 import { Alert } from '../../alert/alert';
 
-import { CodeRenderer, CodeRendererProps } from './code-renderer';
+import type { CodeRendererProps } from './code-renderer';
+import { CodeRenderer } from './code-renderer';
 
 type Props = CodeRendererProps & {
   url: string;

--- a/packages/frontend/src/components/renderers/vega-renderer/vega-renderer-async.tsx
+++ b/packages/frontend/src/components/renderers/vega-renderer/vega-renderer-async.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { BoxProps, Progress } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Progress } from '@chakra-ui/react';
 import { lazy, Suspense } from 'react';
 
 const VegaRenderer = lazy(() => import(/* webpackChunkName: "vega-renderer" */ './vega-renderer'));

--- a/packages/frontend/src/components/renderers/vega-renderer/vega-renderer.tsx
+++ b/packages/frontend/src/components/renderers/vega-renderer/vega-renderer.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { Box, BoxProps } from '@chakra-ui/layout';
-import { ReactNode, useEffect, useState } from 'react';
+import type { BoxProps } from '@chakra-ui/layout';
+import { Box } from '@chakra-ui/layout';
+import type { ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import { memo } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { VegaLite } from 'react-vega';

--- a/packages/frontend/src/components/renderers/vega-renderer/vega-renderer.tsx
+++ b/packages/frontend/src/components/renderers/vega-renderer/vega-renderer.tsx
@@ -57,9 +57,9 @@ export const VegaRenderer = memo(({ specString, transformAssetUri, ...boxProps }
         //height: 'container',
         ...specObj
       });
-    } catch (e: any) {
+    } catch (error_: any) {
       setSpec(undefined);
-      setError(e);
+      setError(error_);
     }
   }, [specString, transformAssetUri]);
 

--- a/packages/frontend/src/components/renderers/video-renderer/video-renderer.tsx
+++ b/packages/frontend/src/components/renderers/video-renderer/video-renderer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { DetailedHTMLProps, ReactNode, VideoHTMLAttributes } from 'react';
+import type { DetailedHTMLProps, ReactNode, VideoHTMLAttributes } from 'react';
 
 import { isRelativeUrl } from '../../../shared/url-utils';
 

--- a/packages/frontend/src/components/renderers/xkcd-chart-renderer/xkcd-chart-renderer-async.tsx
+++ b/packages/frontend/src/components/renderers/xkcd-chart-renderer/xkcd-chart-renderer-async.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { BoxProps, Progress } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Progress } from '@chakra-ui/react';
 import { lazy, Suspense } from 'react';
 
 const XkcdChartRenderer = lazy(() => import(/* webpackChunkName: "xkcd-chart-renderer" */ './xkcd-chart-renderer'));

--- a/packages/frontend/src/components/renderers/xkcd-chart-renderer/xkcd-chart-renderer.tsx
+++ b/packages/frontend/src/components/renderers/xkcd-chart-renderer/xkcd-chart-renderer.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, BoxProps } from '@chakra-ui/layout';
+import type { BoxProps } from '@chakra-ui/layout';
+import { Box } from '@chakra-ui/layout';
 import { Bar, Line, Pie, Radar, StackedBar, XY } from 'chart.xkcd-react';
 import { useEffect, useState } from 'react';
 import ContainerDimensions from 'react-container-dimensions';

--- a/packages/frontend/src/components/renderers/xkcd-chart-renderer/xkcd-chart-renderer.tsx
+++ b/packages/frontend/src/components/renderers/xkcd-chart-renderer/xkcd-chart-renderer.tsx
@@ -66,9 +66,9 @@ export const XkcdChartRenderer = ({ type, configString, ...boxProps }: Props & B
           .replaceAll('chartXkcd.config.positionType.downRight', '4')
       );
       setConfig(configObj);
-    } catch (e: any) {
+    } catch (error_: any) {
       setConfig(undefined);
-      setError(e);
+      setError(error_);
     }
   }, [configString]);
 

--- a/packages/frontend/src/components/secure-route/secure-route.tsx
+++ b/packages/frontend/src/components/secure-route/secure-route.tsx
@@ -17,7 +17,7 @@
 import { useSelector } from 'react-redux';
 
 import { NotAllowedPage } from '../../pages/not-allowed-page/not-allowed-page';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 import { LoginState } from '../../store/user.slice';
 
 /**

--- a/packages/frontend/src/components/settings-sidebar/settings-sidebar.tsx
+++ b/packages/frontend/src/components/settings-sidebar/settings-sidebar.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Heading, VStack } from '@chakra-ui/react';
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { Link } from '../link/link';

--- a/packages/frontend/src/components/sidebar-stack/sidebar-stack.tsx
+++ b/packages/frontend/src/components/sidebar-stack/sidebar-stack.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { BoxProps, Tooltip, VStack } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Tooltip, VStack } from '@chakra-ui/react';
 
 import { SidebarHeading } from '../sidebar-heading/sidebar-heading';
 

--- a/packages/frontend/src/components/team-tag/team-tag.tsx
+++ b/packages/frontend/src/components/team-tag/team-tag.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Tag, TagLabel, TagProps } from '@chakra-ui/react';
+import type { TagProps } from '@chakra-ui/react';
+import { Tag, TagLabel } from '@chakra-ui/react';
 import { useDispatch } from 'react-redux';
 
 import { searchSlice } from '../../store/search.slice';

--- a/packages/frontend/src/components/text-with-icon/text-with-icon.tsx
+++ b/packages/frontend/src/components/text-with-icon/text-with-icon.tsx
@@ -15,8 +15,8 @@
  */
 
 import { HStack, Icon, Text } from '@chakra-ui/react';
-import { ReactElement } from 'react';
-import { IconType } from 'react-icons';
+import type { ReactElement } from 'react';
+import type { IconType } from 'react-icons';
 
 import { iconFactory } from '../../shared/icon-factory';
 

--- a/packages/frontend/src/components/text-with-icon/text-with-icon.tsx
+++ b/packages/frontend/src/components/text-with-icon/text-with-icon.tsx
@@ -33,12 +33,7 @@ type Props =
     };
 
 export const TextWithIcon = ({ children, iconColor = 'frost.400', ...props }: Props) => {
-  let icon: IconType;
-  if ('icon' in props) {
-    icon = props.icon;
-  } else {
-    icon = iconFactory(props.iconName);
-  }
+  const icon: IconType = 'icon' in props ? props.icon : iconFactory(props.iconName);
 
   return (
     <HStack>

--- a/packages/frontend/src/components/user-tag/fetch-user-tag.tsx
+++ b/packages/frontend/src/components/user-tag/fetch-user-tag.tsx
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import { BoxProps } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
 import { memo } from 'react';
 
-import { User } from '../../models/generated/graphql';
+import type { User } from '../../models/generated/graphql';
 import { useUser } from '../../shared/useUser';
 
-import { UserTag, UserTagProps } from './user-tag';
+import type { UserTagProps } from './user-tag';
+import { UserTag } from './user-tag';
 
 type Props = Omit<UserTagProps, 'user'> & { userName: string };
 

--- a/packages/frontend/src/components/user-tag/user-tag.tsx
+++ b/packages/frontend/src/components/user-tag/user-tag.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { Placement, TagProps } from '@chakra-ui/react';
 import {
   Avatar,
   Box,
@@ -21,7 +22,6 @@ import {
   Heading,
   HStack,
   Icon,
-  Placement,
   Popover,
   PopoverArrow,
   PopoverTrigger,
@@ -29,7 +29,6 @@ import {
   PopoverBody,
   Tag,
   TagLabel,
-  TagProps,
   Text,
   Portal,
   Spinner,
@@ -37,7 +36,7 @@ import {
   useColorModeValue
 } from '@chakra-ui/react';
 
-import { User } from '../../models/generated/graphql';
+import type { User } from '../../models/generated/graphql';
 import { iconFactory } from '../../shared/icon-factory';
 import { useUser } from '../../shared/useUser';
 import { Link } from '../link/link';

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -22,7 +22,6 @@ import { Helmet } from 'react-helmet';
 import { Provider as Redux } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { PersistGate } from 'redux-persist/integration/react';
-
 import { Provider as UrqlProvider } from 'urql';
 
 import { AnalyticsHandler } from './components/analytics-handler/analytics-handler';

--- a/packages/frontend/src/models/file-tree.ts
+++ b/packages/frontend/src/models/file-tree.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { InsightFile as InsightFileGQL } from './generated/graphql';
+import type { InsightFile as InsightFileGQL } from './generated/graphql';
 
 // TODO: Replace with a generated GraphQL enum
 export enum InsightFileAction {

--- a/packages/frontend/src/pages/activity-page/activity-page.tsx
+++ b/packages/frontend/src/pages/activity-page/activity-page.tsx
@@ -26,7 +26,7 @@ import { Alert } from '../../components/alert/alert';
 import { generateSearchUrl } from '../../shared/search-url';
 import { useActivities } from '../../shared/useActivities';
 import { activitySlice } from '../../store/activity.slice';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 
 import { ActivityFilterSidebar } from './components/activity-filter-sidebar/activity-filter-sidebar';
 import { ActivitySearchBar } from './components/activity-search-bar/activity-search-bar';

--- a/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/activity-filter-sidebar.tsx
+++ b/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/activity-filter-sidebar.tsx
@@ -92,7 +92,7 @@ export const ActivityFilterSidebar = ({ suggestedFilters, ...boxProps }: Props &
         if (isActuallyFiltered !== isFiltered) {
           dispatch(activitySlice.actions.setIsFiltered(isActuallyFiltered));
         }
-      } catch (e: any) {
+      } catch {
         // If there's a parsing error, it will be detected
         // server-side and displayed elsewhere.
         // Do nothing.

--- a/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/activity-filter-sidebar.tsx
+++ b/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/activity-filter-sidebar.tsx
@@ -20,7 +20,6 @@ import type { ReactElement } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
-
 import { gql, useQuery } from 'urql';
 
 import type { ActivityAutocompleteQuery, AutocompleteResults } from '../../../../models/generated/graphql';

--- a/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/activity-filter-sidebar.tsx
+++ b/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/activity-filter-sidebar.tsx
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-import { BoxProps, StackDivider, VStack } from '@chakra-ui/react';
-import { ReactElement, useEffect, useRef, useState } from 'react';
+import type { BoxProps } from '@chakra-ui/react';
+import { StackDivider, VStack } from '@chakra-ui/react';
+import type { ReactElement } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 
 import { gql, useQuery } from 'urql';
 
-import { ActivityAutocompleteQuery, AutocompleteResults } from '../../../../models/generated/graphql';
+import type { ActivityAutocompleteQuery, AutocompleteResults } from '../../../../models/generated/graphql';
+import type { SearchClause } from '../../../../shared/search';
 import {
   parseSearchQuery,
-  SearchClause,
   SearchCompoundRange,
   SearchMultiTerm,
   SearchRange,
@@ -32,7 +34,7 @@ import {
   toSearchQuery
 } from '../../../../shared/search';
 import { activitySlice } from '../../../../store/activity.slice';
-import { RootState } from '../../../../store/store';
+import type { RootState } from '../../../../store/store';
 
 import { ActivityTypeStack } from './components/activity-type-stack/activity-type-stack';
 import { DateStack } from './components/date-stack/date-stack';

--- a/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/activity-filter-sidebar.tsx
+++ b/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/activity-filter-sidebar.tsx
@@ -18,6 +18,7 @@ import { BoxProps, StackDivider, VStack } from '@chakra-ui/react';
 import { ReactElement, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
+
 import { gql, useQuery } from 'urql';
 
 import { ActivityAutocompleteQuery, AutocompleteResults } from '../../../../models/generated/graphql';

--- a/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/activity-filter-sidebar.tsx
+++ b/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/activity-filter-sidebar.tsx
@@ -184,13 +184,8 @@ export const ActivityFilterSidebar = ({ suggestedFilters, ...boxProps }: Props &
 
       dispatch(activitySlice.actions.setQuery(toSearchQuery(searchClauses)));
     } else {
-      let newClause: SearchClause;
-
-      if (values.length === 1) {
-        newClause = new SearchTerm(key, values[0]);
-      } else {
-        newClause = new SearchMultiTerm(key, values);
-      }
+      const newClause: SearchClause =
+        values.length === 1 ? new SearchTerm(key, values[0]) : new SearchMultiTerm(key, values);
 
       dispatch(activitySlice.actions.setQuery(`${query} ${newClause.toString()}`.trim()));
     }

--- a/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/components/activity-type-stack/activity-type-stack.tsx
+++ b/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/components/activity-type-stack/activity-type-stack.tsx
@@ -19,7 +19,8 @@ import titleize from 'titleize';
 
 import { SidebarStack } from '../../../../../../components/sidebar-stack/sidebar-stack';
 import { ActivityType } from '../../../../../../models/generated/graphql';
-import { SearchClause, SearchMultiTerm, SearchTerm } from '../../../../../../shared/search';
+import type { SearchClause } from '../../../../../../shared/search';
+import { SearchMultiTerm, SearchTerm } from '../../../../../../shared/search';
 
 // This is a manually-curated subset of all Activity Types
 // E.g. we don't need to allow users to filter for LOGIN activities

--- a/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/components/filter-stack/filter-stack.tsx
+++ b/packages/frontend/src/pages/activity-page/components/activity-filter-sidebar/components/filter-stack/filter-stack.tsx
@@ -18,8 +18,8 @@ import { Checkbox } from '@chakra-ui/react';
 import CreatableSelect from 'react-select/creatable';
 
 import { SidebarStack } from '../../../../../../components/sidebar-stack/sidebar-stack';
-import { UniqueValue } from '../../../../../../models/generated/graphql';
-import { SearchTerm } from '../../../../../../shared/search';
+import type { UniqueValue } from '../../../../../../models/generated/graphql';
+import type { SearchTerm } from '../../../../../../shared/search';
 
 interface Props {
   filterKey: string;

--- a/packages/frontend/src/pages/activity-page/components/activity-search-bar/activity-search-bar.tsx
+++ b/packages/frontend/src/pages/activity-page/components/activity-search-bar/activity-search-bar.tsx
@@ -26,14 +26,15 @@ import {
   MenuOptionGroup,
   Tooltip
 } from '@chakra-ui/react';
-import { ReactElement, useEffect, useRef, useState } from 'react';
+import type { ReactElement } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 
 import { iconFactoryAs } from '../../../../shared/icon-factory';
 import { useDebounce } from '../../../../shared/useDebounce';
 import { activitySlice } from '../../../../store/activity.slice';
-import { RootState } from '../../../../store/store';
+import type { RootState } from '../../../../store/store';
 import { ActivitySearchBox } from '../activity-search-box/activity-search-box';
 
 const availableSortFields = [

--- a/packages/frontend/src/pages/activity-page/components/activity-search-box/activity-search-box.tsx
+++ b/packages/frontend/src/pages/activity-page/components/activity-search-box/activity-search-box.tsx
@@ -15,7 +15,7 @@
  */
 
 import { IconButton, Input, InputGroup, InputLeftElement, InputRightElement, Tooltip } from '@chakra-ui/react';
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 
 import { iconFactoryAs } from '../../../../shared/icon-factory';
 

--- a/packages/frontend/src/pages/admin-page/admin-page.tsx
+++ b/packages/frontend/src/pages/admin-page/admin-page.tsx
@@ -18,7 +18,8 @@ import { Flex, Text, VStack } from '@chakra-ui/react';
 import { Helmet } from 'react-helmet';
 import { Route, Routes } from 'react-router-dom';
 
-import { SettingsSection, SettingsSidebar } from '../../components/settings-sidebar/settings-sidebar';
+import type { SettingsSection } from '../../components/settings-sidebar/settings-sidebar';
+import { SettingsSidebar } from '../../components/settings-sidebar/settings-sidebar';
 import { ErrorPage } from '../error-page/error-page';
 
 import { NewsAdmin } from './components/news-admin/news-admin';

--- a/packages/frontend/src/pages/admin-page/components/news-admin/components/edit-news-item/edit-news-item.tsx
+++ b/packages/frontend/src/pages/admin-page/components/news-admin/components/edit-news-item/edit-news-item.tsx
@@ -31,7 +31,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { Card } from '../../../../../../components/card/card';
 import { DatePicker } from '../../../../../../components/date-picker/date-picker';
 import { MarkdownSplitEditor } from '../../../../../../components/markdown-split-editor/markdown-split-editor';
-import { NewsFieldsFragment } from '../../../../../../models/generated/graphql';
+import type { NewsFieldsFragment } from '../../../../../../models/generated/graphql';
 import { iconFactoryAs } from '../../../../../../shared/icon-factory';
 
 export const EditNewsItem = ({

--- a/packages/frontend/src/pages/admin-page/components/news-admin/components/news-item/news-item.tsx
+++ b/packages/frontend/src/pages/admin-page/components/news-admin/components/news-item/news-item.tsx
@@ -17,12 +17,12 @@
 import { Box, Button, Flex, Heading, Text } from '@chakra-ui/react';
 import { DateTime } from 'luxon';
 import { useState } from 'react';
-import { Components } from 'react-markdown';
+import type { Components } from 'react-markdown';
 
 import { Card } from '../../../../../../components/card/card';
 import { getDataAttributes } from '../../../../../../components/markdown-container/chakra-ui-renderer';
 import { MarkdownContainer } from '../../../../../../components/markdown-container/markdown-container';
-import { NewsFieldsFragment } from '../../../../../../models/generated/graphql';
+import type { NewsFieldsFragment } from '../../../../../../models/generated/graphql';
 import { formatDateIntl } from '../../../../../../shared/date-utils';
 import { EditNewsItem } from '../edit-news-item/edit-news-item';
 

--- a/packages/frontend/src/pages/auth-error-page/auth-error-page.tsx
+++ b/packages/frontend/src/pages/auth-error-page/auth-error-page.tsx
@@ -21,6 +21,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { iconFactory } from '../../shared/icon-factory';
 import { RootState } from '../../store/store';
 import { ErrorPage } from '../error-page/error-page';
+
 interface AuthError {
   name: string;
   message: string;

--- a/packages/frontend/src/pages/auth-error-page/auth-error-page.tsx
+++ b/packages/frontend/src/pages/auth-error-page/auth-error-page.tsx
@@ -19,7 +19,7 @@ import { useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { iconFactory } from '../../shared/icon-factory';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 import { ErrorPage } from '../error-page/error-page';
 
 interface AuthError {

--- a/packages/frontend/src/pages/error-page/error-page.tsx
+++ b/packages/frontend/src/pages/error-page/error-page.tsx
@@ -16,7 +16,7 @@
 
 import { useBreakpointValue } from '@chakra-ui/media-query';
 import { Box, Button, Heading, HStack, Icon, Tag, TagLabel, Text, VStack, Wrap, WrapItem } from '@chakra-ui/react';
-import { ReactChild } from 'react';
+import type { ReactChild } from 'react';
 import { Helmet } from 'react-helmet';
 
 import { Card } from '../../components/card/card';

--- a/packages/frontend/src/pages/help-page/components/help-sidebar/help-sidebar.tsx
+++ b/packages/frontend/src/pages/help-page/components/help-sidebar/help-sidebar.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import type { BoxProps } from '@chakra-ui/react';
 import {
   Badge,
   Box,
-  BoxProps,
   Drawer,
   DrawerBody,
   DrawerCloseButton,

--- a/packages/frontend/src/pages/help-page/help-page.tsx
+++ b/packages/frontend/src/pages/help-page/help-page.tsx
@@ -17,7 +17,7 @@
 import { Flex, Heading, Icon, Text, VStack, Wrap, WrapItem } from '@chakra-ui/react';
 import { useState } from 'react';
 import { Helmet } from 'react-helmet';
-import { IconType } from 'react-icons';
+import type { IconType } from 'react-icons';
 import { useSelector } from 'react-redux';
 import { Routes, Route } from 'react-router-dom';
 
@@ -26,7 +26,7 @@ import { ExternalLink } from '../../components/external-link/external-link';
 import { Link } from '../../components/link/link';
 import { chatIcon } from '../../shared/chat-icon';
 import { iconFactory } from '../../shared/icon-factory';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 
 import { GettingStartedPage } from './components/getting-started-page/getting-started-page';
 import { IntegrationsPage } from './components/integrations-page/integrations-page';

--- a/packages/frontend/src/pages/insight-editor/components/insight-editor-header/insight-editor-header.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-editor-header/insight-editor-header.tsx
@@ -38,8 +38,10 @@ import {
   useDisclosure,
   VStack
 } from '@chakra-ui/react';
-import { RefObject, useRef, useState } from 'react';
-import { UseFormReturn, useWatch } from 'react-hook-form';
+import type { RefObject } from 'react';
+import { useRef, useState } from 'react';
+import type { UseFormReturn } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import titleize from 'titleize';
 
@@ -48,7 +50,7 @@ import { ItemTypeIcon } from '../../../../components/item-type-icon/item-type-ic
 import { Linkify } from '../../../../components/linkify/linkify';
 import { formatFormError } from '../../../../shared/form-utils';
 import { getItemType } from '../../../../shared/item-type';
-import { DraftForm } from '../../draft-form';
+import type { DraftForm } from '../../draft-form';
 
 interface Props {
   insight: any;

--- a/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/insight-editor-sidebar.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/insight-editor-sidebar.tsx
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { Flex, FlexProps } from '@chakra-ui/react';
-import { UseFormReturn } from 'react-hook-form';
+import type { FlexProps } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
+import type { UseFormReturn } from 'react-hook-form';
 
-import { InsightFile } from '../../../../models/file-tree';
-import { Insight } from '../../../../models/generated/graphql';
-import { InsightFileTree } from '../../../../shared/file-tree';
+import type { InsightFile } from '../../../../models/file-tree';
+import type { Insight } from '../../../../models/generated/graphql';
+import type { InsightFileTree } from '../../../../shared/file-tree';
 
 import { SidebarFiles } from './sidebar-files';
 

--- a/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/sidebar-files.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/sidebar-files.tsx
@@ -15,12 +15,12 @@
  */
 
 import { useBreakpointValue } from '@chakra-ui/media-query';
+import type { FlexProps } from '@chakra-ui/react';
 import {
   Button,
   Box,
   Collapse,
   Flex,
-  FlexProps,
   Icon,
   IconButton,
   Spinner,
@@ -38,9 +38,10 @@ import { gql } from 'urql';
 import { FileBrowser } from '../../../../components/file-browser/file-browser';
 import { FileUploadArea } from '../../../../components/file-upload-area/file-upload-area';
 import { SidebarHeading } from '../../../../components/sidebar-heading/sidebar-heading';
-import { FileOrFolder, InsightFile, InsightFileAction, InsightFolder } from '../../../../models/file-tree';
-import { UploadSingleFileMutation } from '../../../../models/generated/graphql';
-import { InsightFileTree } from '../../../../shared/file-tree';
+import type { FileOrFolder, InsightFile, InsightFolder } from '../../../../models/file-tree';
+import { InsightFileAction } from '../../../../models/file-tree';
+import type { UploadSingleFileMutation } from '../../../../models/generated/graphql';
+import type { InsightFileTree } from '../../../../shared/file-tree';
 import { iconFactory, iconFactoryAs } from '../../../../shared/icon-factory';
 import { urqlClient } from '../../../../urql';
 

--- a/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/sidebar-files.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/sidebar-files.tsx
@@ -32,7 +32,6 @@ import {
 } from '@chakra-ui/react';
 import { nanoid } from 'nanoid';
 import { useCallback, useState } from 'react';
-
 import { gql } from 'urql';
 
 import { FileBrowser } from '../../../../components/file-browser/file-browser';

--- a/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/sidebar-files.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/sidebar-files.tsx
@@ -32,6 +32,7 @@ import {
 } from '@chakra-ui/react';
 import { nanoid } from 'nanoid';
 import { useCallback, useState } from 'react';
+
 import { gql } from 'urql';
 
 import { FileBrowser } from '../../../../components/file-browser/file-browser';

--- a/packages/frontend/src/pages/insight-editor/components/insight-file-editor/insight-file-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-file-editor/insight-file-editor.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Flex, FlexProps, Spinner } from '@chakra-ui/react';
+import type { FlexProps } from '@chakra-ui/react';
+import { Flex, Spinner } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 
 import { Alert } from '../../../../components/alert/alert';
@@ -22,8 +23,9 @@ import { CodeEditor } from '../../../../components/code-editor/code-editor';
 import { FileViewer } from '../../../../components/file-viewer/file-viewer';
 import { HtmlSplitEditor } from '../../../../components/html-split-editor/html-split-editor';
 import { MarkdownSplitEditor } from '../../../../components/markdown-split-editor/markdown-split-editor';
-import { InsightFile, InsightFileAction } from '../../../../models/file-tree';
-import { Insight, InsightFileInput, UploadSingleFileMutation } from '../../../../models/generated/graphql';
+import type { InsightFile } from '../../../../models/file-tree';
+import { InsightFileAction } from '../../../../models/file-tree';
+import type { Insight, InsightFileInput, UploadSingleFileMutation } from '../../../../models/generated/graphql';
 import {
   getLanguageForMime,
   getMimeForFileName,

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-authors.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-authors.tsx
@@ -17,6 +17,7 @@
 import { FormControl, FormHelperText, FormLabel, InputGroup, InputLeftElement } from '@chakra-ui/react';
 import { Controller } from 'react-hook-form';
 import CreatableSelect from 'react-select/creatable';
+
 import { gql, useQuery } from 'urql';
 
 import { UsersAsAuthorsQuery } from '../../../../models/generated/graphql';

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-authors.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-authors.tsx
@@ -17,7 +17,6 @@
 import { FormControl, FormHelperText, FormLabel, InputGroup, InputLeftElement } from '@chakra-ui/react';
 import { Controller } from 'react-hook-form';
 import CreatableSelect from 'react-select/creatable';
-
 import { gql, useQuery } from 'urql';
 
 import type { UsersAsAuthorsQuery } from '../../../../models/generated/graphql';

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-authors.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-authors.tsx
@@ -20,7 +20,7 @@ import CreatableSelect from 'react-select/creatable';
 
 import { gql, useQuery } from 'urql';
 
-import { UsersAsAuthorsQuery } from '../../../../models/generated/graphql';
+import type { UsersAsAuthorsQuery } from '../../../../models/generated/graphql';
 import { iconFactoryAs } from '../../../../shared/icon-factory';
 
 const USERS_QUERY = gql`

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-metadata-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-metadata-editor.tsx
@@ -37,7 +37,6 @@ import type { UseFormReturn } from 'react-hook-form';
 import { Controller, useWatch } from 'react-hook-form';
 import Select from 'react-select';
 import titleize from 'titleize';
-
 import { gql, useQuery } from 'urql';
 
 import { Alert } from '../../../../components/alert/alert';

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-metadata-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-metadata-editor.tsx
@@ -33,18 +33,19 @@ import {
   VStack
 } from '@chakra-ui/react';
 import { useEffect } from 'react';
-import { Controller, UseFormReturn, useWatch } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
+import { Controller, useWatch } from 'react-hook-form';
 import Select from 'react-select';
 import titleize from 'titleize';
 
 import { gql, useQuery } from 'urql';
 
 import { Alert } from '../../../../components/alert/alert';
-import { Insight } from '../../../../models/generated/graphql';
+import type { Insight } from '../../../../models/generated/graphql';
 import { formatFormError } from '../../../../shared/form-utils';
 import { iconFactory, iconFactoryAs } from '../../../../shared/icon-factory';
 import { ItemType } from '../../../../shared/item-type';
-import { DraftForm } from '../../draft-form';
+import type { DraftForm } from '../../draft-form';
 
 import { InsightAuthors } from './insight-authors';
 import { InsightLinks } from './insight-links';

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-metadata-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-metadata-editor.tsx
@@ -36,6 +36,7 @@ import { useEffect } from 'react';
 import { Controller, UseFormReturn, useWatch } from 'react-hook-form';
 import Select from 'react-select';
 import titleize from 'titleize';
+
 import { gql, useQuery } from 'urql';
 
 import { Alert } from '../../../../components/alert/alert';

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-tags.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-tags.tsx
@@ -21,7 +21,7 @@ import titleize from 'titleize';
 
 import { gql, useQuery } from 'urql';
 
-import { AutocompleteInsightTagsQuery } from '../../../../models/generated/graphql';
+import type { AutocompleteInsightTagsQuery } from '../../../../models/generated/graphql';
 import { iconFactoryAs } from '../../../../shared/icon-factory';
 
 const AUTOCOMPLETE_QUERY = gql`

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-tags.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-tags.tsx
@@ -18,7 +18,6 @@ import { FormControl, FormHelperText, FormLabel, InputGroup, InputLeftElement } 
 import { Controller, useWatch } from 'react-hook-form';
 import CreatableSelect from 'react-select/creatable';
 import titleize from 'titleize';
-
 import { gql, useQuery } from 'urql';
 
 import type { AutocompleteInsightTagsQuery } from '../../../../models/generated/graphql';

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-tags.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-tags.tsx
@@ -18,6 +18,7 @@ import { FormControl, FormHelperText, FormLabel, InputGroup, InputLeftElement } 
 import { Controller, useWatch } from 'react-hook-form';
 import CreatableSelect from 'react-select/creatable';
 import titleize from 'titleize';
+
 import { gql, useQuery } from 'urql';
 
 import { AutocompleteInsightTagsQuery } from '../../../../models/generated/graphql';

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-team.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-team.tsx
@@ -23,9 +23,9 @@ import titleize from 'titleize';
 import { gql, useQuery } from 'urql';
 
 import { Link } from '../../../../components/link/link';
-import { AutocompleteInsightTeamQuery } from '../../../../models/generated/graphql';
+import type { AutocompleteInsightTeamQuery } from '../../../../models/generated/graphql';
 import { iconFactoryAs } from '../../../../shared/icon-factory';
-import { RootState } from '../../../../store/store';
+import type { RootState } from '../../../../store/store';
 
 const AUTOCOMPLETE_QUERY = gql`
   query AutocompleteInsightTeam {

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-team.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-team.tsx
@@ -19,7 +19,6 @@ import { Controller, useWatch } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 import CreatableSelect from 'react-select/creatable';
 import titleize from 'titleize';
-
 import { gql, useQuery } from 'urql';
 
 import { Link } from '../../../../components/link/link';

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-team.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/insight-team.tsx
@@ -19,6 +19,7 @@ import { Controller, useWatch } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 import CreatableSelect from 'react-select/creatable';
 import titleize from 'titleize';
+
 import { gql, useQuery } from 'urql';
 
 import { Link } from '../../../../components/link/link';

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/published-date.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/published-date.tsx
@@ -38,7 +38,7 @@ export const PublishedDate = ({ insight, form }) => {
     let publishedDate: string | null;
     try {
       publishedDate = DateTime.fromJSDate(selectedDate).toISODate();
-    } catch (error: any) {
+    } catch {
       publishedDate = null;
     }
     setValue('metadata.publishedDate', publishedDate);

--- a/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/template-selection.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-metadata-editor/template-selection.tsx
@@ -27,13 +27,14 @@ import {
   FormLabel,
   useDisclosure
 } from '@chakra-ui/react';
-import { RefObject, useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+import { useEffect, useRef } from 'react';
 import { useWatch } from 'react-hook-form';
-import { UseFormReturn } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 import Select from 'react-select';
 import titleize from 'titleize';
 
-import { Insight } from '../../../../models/generated/graphql';
+import type { Insight } from '../../../../models/generated/graphql';
 
 interface Props {
   insight: any;

--- a/packages/frontend/src/pages/insight-editor/draft-form.ts
+++ b/packages/frontend/src/pages/insight-editor/draft-form.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {
+import type {
   InsightCreationInput,
   InsightFileInput,
   InsightMetadataInput,

--- a/packages/frontend/src/pages/insight-editor/insight-draft-container.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-draft-container.tsx
@@ -18,7 +18,6 @@ import { useToast } from '@chakra-ui/react';
 import isEqual from 'lodash/isEqual';
 import { nanoid } from 'nanoid';
 import { useState } from 'react';
-
 import { gql, useMutation } from 'urql';
 
 import { Alert } from '../../components/alert/alert';

--- a/packages/frontend/src/pages/insight-editor/insight-draft-container.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-draft-container.tsx
@@ -18,6 +18,7 @@ import { useToast } from '@chakra-ui/react';
 import isEqual from 'lodash/isEqual';
 import { nanoid } from 'nanoid';
 import { useState } from 'react';
+
 import { gql, useMutation } from 'urql';
 
 import { Alert } from '../../components/alert/alert';

--- a/packages/frontend/src/pages/insight-editor/insight-draft-container.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-draft-container.tsx
@@ -22,7 +22,7 @@ import { useState } from 'react';
 import { gql, useMutation } from 'urql';
 
 import { Alert } from '../../components/alert/alert';
-import { Insight, UpdatedInsight, UploadSingleFileMutation } from '../../models/generated/graphql';
+import type { Insight, UpdatedInsight, UploadSingleFileMutation } from '../../models/generated/graphql';
 import { urqlClient } from '../../urql';
 
 import { InsightEditor } from './insight-editor';

--- a/packages/frontend/src/pages/insight-editor/insight-draft-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-draft-editor.tsx
@@ -19,7 +19,6 @@ import { nanoid } from 'nanoid';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-
 import { gql } from 'urql';
 
 import { InsightFileAction } from '../../models/file-tree';

--- a/packages/frontend/src/pages/insight-editor/insight-draft-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-draft-editor.tsx
@@ -19,6 +19,7 @@ import { nanoid } from 'nanoid';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+
 import { gql } from 'urql';
 
 import { InsightFileAction } from '../../models/file-tree';

--- a/packages/frontend/src/pages/insight-editor/insight-draft-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-draft-editor.tsx
@@ -23,10 +23,11 @@ import { useNavigate } from 'react-router-dom';
 import { gql } from 'urql';
 
 import { InsightFileAction } from '../../models/file-tree';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 import { urqlClient } from '../../urql';
 
-import { DraftDataInput, InsightDraftContainer } from './insight-draft-container';
+import type { DraftDataInput } from './insight-draft-container';
+import { InsightDraftContainer } from './insight-draft-container';
 
 const DRAFT_QUERY = gql`
   query draftByKey($draftKey: String!) {

--- a/packages/frontend/src/pages/insight-editor/insight-draft-switcher.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-draft-switcher.tsx
@@ -39,6 +39,7 @@ import { nanoid } from 'nanoid';
 import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+
 import { gql, useMutation, useQuery } from 'urql';
 
 import { Link as RouterLink } from '../../components/link/link';

--- a/packages/frontend/src/pages/insight-editor/insight-draft-switcher.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-draft-switcher.tsx
@@ -39,7 +39,6 @@ import { nanoid } from 'nanoid';
 import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-
 import { gql, useMutation, useQuery } from 'urql';
 
 import { Link as RouterLink } from '../../components/link/link';

--- a/packages/frontend/src/pages/insight-editor/insight-draft-switcher.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-draft-switcher.tsx
@@ -43,10 +43,10 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { gql, useMutation, useQuery } from 'urql';
 
 import { Link as RouterLink } from '../../components/link/link';
-import { Insight } from '../../models/generated/graphql';
+import type { Insight } from '../../models/generated/graphql';
 import { formatRelativeIntl } from '../../shared/date-utils';
 import { iconFactory, iconFactoryAs } from '../../shared/icon-factory';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 import { UserHealthCheck } from '../main-page/components/user-health-check/user-health-check';
 
 import { InsightDraftEditor } from './insight-draft-editor';

--- a/packages/frontend/src/pages/insight-editor/insight-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-editor.tsx
@@ -312,7 +312,7 @@ export const InsightEditor = memo(
 
       if (isRelativeUrl(uri)) {
         if (uri[0] === '/') {
-          uri = uri.substring(1);
+          uri = uri.slice(1);
         }
 
         const file = fileTree.getFileByPath(uri);

--- a/packages/frontend/src/pages/insight-editor/insight-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-editor.tsx
@@ -32,6 +32,7 @@ import { useForm, useWatch } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import urljoin from 'url-join';
+
 import { gql, useMutation, useQuery } from 'urql';
 
 import { FileOrFolder, InsightFileAction } from '../../models/file-tree';

--- a/packages/frontend/src/pages/insight-editor/insight-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-editor.tsx
@@ -34,20 +34,21 @@ import { useNavigate } from 'react-router-dom';
 
 import { gql, useMutation, useQuery } from 'urql';
 
-import { FileOrFolder, InsightFileAction } from '../../models/file-tree';
-import { Insight, InsightFileInput, UploadSingleFileMutation } from '../../models/generated/graphql';
+import type { FileOrFolder } from '../../models/file-tree';
+import { InsightFileAction } from '../../models/file-tree';
+import type { Insight, InsightFileInput, UploadSingleFileMutation } from '../../models/generated/graphql';
 import { InsightFileTree, isFile } from '../../shared/file-tree';
 import { isRelativeUrl, urljoin } from '../../shared/url-utils';
 import { useDebounce } from '../../shared/useDebounce';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 import { urqlClient } from '../../urql';
 
 import { InsightEditorHeader } from './components/insight-editor-header/insight-editor-header';
 import { InsightEditorSidebar } from './components/insight-editor-sidebar/insight-editor-sidebar';
 import { InsightFileEditor } from './components/insight-file-editor/insight-file-editor';
 import { InsightMetadataEditor } from './components/insight-metadata-editor/insight-metadata-editor';
-import { DraftForm } from './draft-form';
-import { DraftDataInput } from './insight-draft-container';
+import type { DraftForm } from './draft-form';
+import type { DraftDataInput } from './insight-draft-container';
 
 const TEMPLATES_QUERY = gql`
   query Templates {

--- a/packages/frontend/src/pages/insight-editor/insight-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-editor.tsx
@@ -31,7 +31,6 @@ import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-
 import { gql, useMutation, useQuery } from 'urql';
 
 import type { FileOrFolder } from '../../models/file-tree';

--- a/packages/frontend/src/pages/insight-editor/insight-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-editor.tsx
@@ -31,14 +31,13 @@ import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import urljoin from 'url-join';
 
 import { gql, useMutation, useQuery } from 'urql';
 
 import { FileOrFolder, InsightFileAction } from '../../models/file-tree';
 import { Insight, InsightFileInput, UploadSingleFileMutation } from '../../models/generated/graphql';
 import { InsightFileTree, isFile } from '../../shared/file-tree';
-import { isRelativeUrl } from '../../shared/url-utils';
+import { isRelativeUrl, urljoin } from '../../shared/url-utils';
 import { useDebounce } from '../../shared/useDebounce';
 import { RootState } from '../../store/store';
 import { urqlClient } from '../../urql';

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/action-bar/action-bar.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/action-bar/action-bar.tsx
@@ -32,6 +32,7 @@ import {
 import { useSelector } from 'react-redux';
 import { Link as RouterLink } from 'react-router-dom';
 import titleize from 'titleize';
+
 import { gql, useMutation } from 'urql';
 
 import { InsightCollaboratorsModal } from '../../../../../../components/insight-collaborators-modal/insight-collaborators-modal';

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/action-bar/action-bar.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/action-bar/action-bar.tsx
@@ -32,7 +32,6 @@ import {
 import { useSelector } from 'react-redux';
 import { Link as RouterLink } from 'react-router-dom';
 import titleize from 'titleize';
-
 import { gql, useMutation } from 'urql';
 
 import { InsightCollaboratorsModal } from '../../../../../../components/insight-collaborators-modal/insight-collaborators-modal';

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/action-bar/action-bar.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/action-bar/action-bar.tsx
@@ -39,9 +39,9 @@ import { InsightCollaboratorsModal } from '../../../../../../components/insight-
 import { LikeButton } from '../../../../../../components/like-button/like-button';
 import { LikedByTooltip } from '../../../../../../components/liked-by-tooltip/liked-by-tooltip';
 import { NumberIconButton } from '../../../../../../components/number-icon-button/number-icon-button';
-import { Insight, User } from '../../../../../../models/generated/graphql';
+import type { Insight, User } from '../../../../../../models/generated/graphql';
 import { iconFactory, iconFactoryAs } from '../../../../../../shared/icon-factory';
-import { RootState } from '../../../../../../store/store';
+import type { RootState } from '../../../../../../store/store';
 import { CloneDialog } from '../clone-dialog/clone-dialog';
 import { DeleteDialog } from '../delete-dialog/delete-dialog';
 

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/clone-dialog/clone-dialog.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/clone-dialog/clone-dialog.tsx
@@ -27,10 +27,11 @@ import {
   Text,
   VStack
 } from '@chakra-ui/react';
-import { useRef, RefObject, useState } from 'react';
+import type { RefObject } from 'react';
+import { useRef, useState } from 'react';
 import titleize from 'titleize';
 
-import { Insight } from '../../../../../../models/generated/graphql';
+import type { Insight } from '../../../../../../models/generated/graphql';
 import { iconFactory } from '../../../../../../shared/icon-factory';
 
 interface Props {

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/delete-dialog/delete-dialog.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/delete-dialog/delete-dialog.tsx
@@ -27,11 +27,12 @@ import {
   Text,
   VStack
 } from '@chakra-ui/react';
-import { useRef, RefObject, useState } from 'react';
+import type { RefObject } from 'react';
+import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import titleize from 'titleize';
 
-import { Insight } from '../../../../../../models/generated/graphql';
+import type { Insight } from '../../../../../../models/generated/graphql';
 import { iconFactory } from '../../../../../../shared/icon-factory';
 
 interface Props {

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/export-footer/export-footer.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/export-footer/export-footer.tsx
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { Box, BoxProps, Stack, Tag, TagLabel, useColorModeValue } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Box, Stack, Tag, TagLabel, useColorModeValue } from '@chakra-ui/react';
 
 import { Card } from '../../../../../../components/card/card';
 import { Link } from '../../../../../../components/link/link';
 import { SidebarHeading } from '../../../../../../components/sidebar-heading/sidebar-heading';
-import { Insight } from '../../../../../../models/generated/graphql';
+import type { Insight } from '../../../../../../models/generated/graphql';
 
 export const ExportFooter = ({ insight, ...props }: { insight: Insight } & BoxProps) => {
   const fileBgColor = useColorModeValue('snowstorm.300', 'gray.700');

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/export-header/export-header.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/export-header/export-header.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Badge, Box, BoxProps, HStack, Text, Tooltip, VStack, Wrap, WrapItem } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Badge, Box, HStack, Text, Tooltip, VStack, Wrap, WrapItem } from '@chakra-ui/react';
 import { DateTime } from 'luxon';
 
 import { Card } from '../../../../../../components/card/card';
@@ -22,7 +23,7 @@ import { InsightTag } from '../../../../../../components/insight-tag/insight-tag
 import { Linkify } from '../../../../../../components/linkify/linkify';
 import { SidebarHeading } from '../../../../../../components/sidebar-heading/sidebar-heading';
 import { UserTag } from '../../../../../../components/user-tag/user-tag';
-import { Insight } from '../../../../../../models/generated/graphql';
+import type { Insight } from '../../../../../../models/generated/graphql';
 import { formatDateIntl, formatRelativeIntl } from '../../../../../../shared/date-utils';
 
 export const ExportHeader = ({ insight, ...props }: { insight: Insight } & BoxProps) => {

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/github-button/github-button.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/github-button/github-button.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { BoxProps, IconButton, Tooltip } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { IconButton, Tooltip } from '@chakra-ui/react';
 import titleize from 'titleize';
 
 import { ExternalLink } from '../../../../../../components/external-link/external-link';
-import { Insight } from '../../../../../../models/generated/graphql';
+import type { Insight } from '../../../../../../models/generated/graphql';
 import { iconFactoryAs } from '../../../../../../shared/icon-factory';
 
 interface Props {

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-activity/insight-activity.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-activity/insight-activity.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { Box, BoxProps, Flex, VStack } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Box, Flex, VStack } from '@chakra-ui/react';
 
 import { FetchActivityList } from '../../../../../../components/activity-list/fetch-activity-list';
 import { Crumbs } from '../../../../../../components/crumbs/crumbs';
-import { Insight } from '../../../../../../models/generated/graphql';
+import type { Insight } from '../../../../../../models/generated/graphql';
 
 interface Props {
   insight: Insight;

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-comments/components/comment-card/comment-card.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-comments/components/comment-card/comment-card.tsx
@@ -23,10 +23,10 @@ import { LikeButton } from '../../../../../../../../components/like-button/like-
 import { LikedByTooltip } from '../../../../../../../../components/liked-by-tooltip/liked-by-tooltip';
 import { Link } from '../../../../../../../../components/link/link';
 import { MarkdownContainer } from '../../../../../../../../components/markdown-container/markdown-container';
-import { Comment, User } from '../../../../../../../../models/generated/graphql';
+import type { Comment, User } from '../../../../../../../../models/generated/graphql';
 import { formatDateIntl } from '../../../../../../../../shared/date-utils';
 import { iconFactoryAs } from '../../../../../../../../shared/icon-factory';
-import { RootState } from '../../../../../../../../store/store';
+import type { RootState } from '../../../../../../../../store/store';
 import { ReplyCard } from '../reply-card/reply-card';
 
 interface Props {

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-comments/components/reply-card/delete-comment-button.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-comments/components/reply-card/delete-comment-button.tsx
@@ -23,7 +23,8 @@ import {
   AlertDialogOverlay,
   Button
 } from '@chakra-ui/react';
-import { RefObject, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+import { useRef, useState } from 'react';
 
 import { DeleteIconButton } from '../../../../../../../../components/delete-icon-button/delete-icon-button';
 

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-comments/components/reply-card/reply-card.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-comments/components/reply-card/reply-card.tsx
@@ -18,7 +18,7 @@ import { Button, FormControl, Heading, HStack, Textarea, VStack } from '@chakra-
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { Comment } from '../../../../../../../../models/generated/graphql';
+import type { Comment } from '../../../../../../../../models/generated/graphql';
 
 import { DeleteCommentButton } from './delete-comment-button';
 

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-comments/insight-comments.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-comments/insight-comments.tsx
@@ -17,7 +17,6 @@
 import type { BoxProps } from '@chakra-ui/react';
 import { Center, Flex, Heading, HStack, Spinner, StackDivider, Text, useToast, VStack } from '@chakra-ui/react';
 import { useSelector } from 'react-redux';
-
 import { gql, useMutation, useQuery } from 'urql';
 
 import { Alert } from '../../../../../../components/alert/alert';

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-comments/insight-comments.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-comments/insight-comments.tsx
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 
-import {
-  BoxProps,
-  Center,
-  Flex,
-  Heading,
-  HStack,
-  Spinner,
-  StackDivider,
-  Text,
-  useToast,
-  VStack
-} from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Center, Flex, Heading, HStack, Spinner, StackDivider, Text, useToast, VStack } from '@chakra-ui/react';
 import { useSelector } from 'react-redux';
 
 import { gql, useMutation, useQuery } from 'urql';
@@ -33,9 +23,9 @@ import { gql, useMutation, useQuery } from 'urql';
 import { Alert } from '../../../../../../components/alert/alert';
 import { Card } from '../../../../../../components/card/card';
 import { Crumbs } from '../../../../../../components/crumbs/crumbs';
-import { Comment, CommentConnection, Insight } from '../../../../../../models/generated/graphql';
+import type { Comment, CommentConnection, Insight } from '../../../../../../models/generated/graphql';
 import { useLikedBy } from '../../../../../../shared/useLikedBy';
-import { RootState } from '../../../../../../store/store';
+import type { RootState } from '../../../../../../store/store';
 
 import { CommentCard } from './components/comment-card/comment-card';
 import { ReplyCard } from './components/reply-card/reply-card';

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-comments/insight-comments.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-comments/insight-comments.tsx
@@ -27,6 +27,7 @@ import {
   VStack
 } from '@chakra-ui/react';
 import { useSelector } from 'react-redux';
+
 import { gql, useMutation, useQuery } from 'urql';
 
 import { Alert } from '../../../../../../components/alert/alert';

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-file-viewer/insight-file-viewer.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-file-viewer/insight-file-viewer.tsx
@@ -17,8 +17,9 @@
 import { useParams } from 'react-router-dom';
 
 import { Alert } from '../../../../../../components/alert/alert';
-import { FileViewer, FileViewerProps } from '../../../../../../components/file-viewer/file-viewer';
-import { Insight, InsightFile } from '../../../../../../models/generated/graphql';
+import type { FileViewerProps } from '../../../../../../components/file-viewer/file-viewer';
+import { FileViewer } from '../../../../../../components/file-viewer/file-viewer';
+import type { Insight, InsightFile } from '../../../../../../models/generated/graphql';
 
 const preferredMimeTypes = {
   'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'application/pdf',

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-header/insight-header.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-header/insight-header.tsx
@@ -17,7 +17,7 @@
 import { Box, Flex, Heading, HStack, Stack } from '@chakra-ui/react';
 
 import { ItemTypeIcon } from '../../../../../../components/item-type-icon/item-type-icon';
-import { Insight, User } from '../../../../../../models/generated/graphql';
+import type { Insight, User } from '../../../../../../models/generated/graphql';
 import { ActionBar } from '../action-bar/action-bar';
 import { NavigationButtons } from '../navigation-buttons/navigation-buttons';
 

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-infobar/insight-infobar.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-infobar/insight-infobar.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { StackProps } from '@chakra-ui/react';
 import {
   Badge,
   Box,
@@ -23,7 +24,6 @@ import {
   Icon,
   IconButton,
   Stack,
-  StackProps,
   Tag,
   TagLabel,
   Text,
@@ -42,7 +42,7 @@ import { Linkify } from '../../../../../../components/linkify/linkify';
 import { SidebarHeading } from '../../../../../../components/sidebar-heading/sidebar-heading';
 import { TeamTag } from '../../../../../../components/team-tag/team-tag';
 import { UserTag } from '../../../../../../components/user-tag/user-tag';
-import { Insight } from '../../../../../../models/generated/graphql';
+import type { Insight } from '../../../../../../models/generated/graphql';
 import { formatDateIntl, formatRelativeIntl } from '../../../../../../shared/date-utils';
 import { iconFactory, iconFactoryAs } from '../../../../../../shared/icon-factory';
 import { groupInsightLinks } from '../../../../../../shared/insight-utils';

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-sidebar/insight-sidebar.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-sidebar/insight-sidebar.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import type { BoxProps } from '@chakra-ui/react';
 import {
   Badge,
   Box,
-  BoxProps,
   Flex,
   HStack,
   Icon,
@@ -41,7 +41,7 @@ import { SidebarHeading } from '../../../../../../components/sidebar-heading/sid
 import { SidebarStack } from '../../../../../../components/sidebar-stack/sidebar-stack';
 import { TeamTag } from '../../../../../../components/team-tag/team-tag';
 import { UserTag } from '../../../../../../components/user-tag/user-tag';
-import { Insight } from '../../../../../../models/generated/graphql';
+import type { Insight } from '../../../../../../models/generated/graphql';
 import { formatDateIntl, formatRelativeIntl } from '../../../../../../shared/date-utils';
 import { iconFactory } from '../../../../../../shared/icon-factory';
 import { groupInsightLinks } from '../../../../../../shared/insight-utils';

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/navigation-buttons/navigation-buttons.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/navigation-buttons/navigation-buttons.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { BoxProps, HStack, IconButton, Tooltip } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { HStack, IconButton, Tooltip } from '@chakra-ui/react';
 import titleize from 'titleize';
 
 import { Link } from '../../../../../../components/link/link';
-import { Insight } from '../../../../../../models/generated/graphql';
+import type { Insight } from '../../../../../../models/generated/graphql';
 import { iconFactoryAs } from '../../../../../../shared/icon-factory';
 
 interface Props {

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/page-header/page-header.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/page-header/page-header.tsx
@@ -18,7 +18,7 @@ import { Box, Heading, HStack, Stack, Text, VStack } from '@chakra-ui/react';
 
 import { ItemTypeIcon } from '../../../../../../components/item-type-icon/item-type-icon';
 import { Linkify } from '../../../../../../components/linkify/linkify';
-import { Insight, User } from '../../../../../../models/generated/graphql';
+import type { Insight, User } from '../../../../../../models/generated/graphql';
 import { getInsightGradient } from '../../../../../../shared/gradient';
 import { ActionBar } from '../action-bar/action-bar';
 import { NavigationButtons } from '../navigation-buttons/navigation-buttons';

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/share-menu/share-menu.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/share-menu/share-menu.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import type { BoxProps } from '@chakra-ui/react';
 import {
-  BoxProps,
   Modal,
   ModalOverlay,
   ModalContent,
@@ -30,7 +30,7 @@ import {
 import { IconButtonMenu } from '../../../../../../components/icon-button-menu/icon-button-menu';
 import { IexMenuItem } from '../../../../../../components/iex-menu-item/iex-menu-item';
 import { CodeRenderer } from '../../../../../../components/renderers/code-renderer/code-renderer';
-import { Insight } from '../../../../../../models/generated/graphql';
+import type { Insight } from '../../../../../../models/generated/graphql';
 import { iconFactory } from '../../../../../../shared/icon-factory';
 
 const EmbedModal = ({ insight }: { insight: Insight }) => {

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/insight-viewer.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/insight-viewer.tsx
@@ -29,7 +29,7 @@ import { InsightFileViewer } from './components/insight-file-viewer/insight-file
 import { InsightHeader } from './components/insight-header/insight-header';
 import { InsightInfobar } from './components/insight-infobar/insight-infobar';
 import { InsightSidebar } from './components/insight-sidebar/insight-sidebar';
-import { ItemTypeViewerProps } from './item-type-viewer';
+import type { ItemTypeViewerProps } from './item-type-viewer';
 import { PageViewer } from './page-viewer';
 
 /**

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/item-type-viewer.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/item-type-viewer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Insight, User } from '../../../../models/generated/graphql';
+import type { Insight, User } from '../../../../models/generated/graphql';
 
 import { InsightViewer } from './insight-viewer';
 import { PageViewer } from './page-viewer';

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/page-viewer.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/page-viewer.tsx
@@ -28,7 +28,7 @@ import { InsightComments } from './components/insight-comments/insight-comments'
 import { InsightFileViewer } from './components/insight-file-viewer/insight-file-viewer';
 import { InsightInfobar } from './components/insight-infobar/insight-infobar';
 import { PageHeader } from './components/page-header/page-header';
-import { ItemTypeViewerProps } from './item-type-viewer';
+import type { ItemTypeViewerProps } from './item-type-viewer';
 
 /**
  * Main pane of content---shared with normal/export view

--- a/packages/frontend/src/pages/insight-page/insight-page.tsx
+++ b/packages/frontend/src/pages/insight-page/insight-page.tsx
@@ -22,7 +22,7 @@ import { useNavigate, useParams, Routes, Route } from 'react-router-dom';
 import { Alert } from '../../components/alert/alert';
 import { useInsight } from '../../shared/useInsight';
 import { useLikedBy } from '../../shared/useLikedBy';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 import { InsightDraftSwitcher } from '../insight-editor/insight-draft-switcher';
 import { InsightNotFoundPage } from '../insight-not-found-page/insight-not-found-page';
 

--- a/packages/frontend/src/pages/main-page/components/about-modal/about-modal.tsx
+++ b/packages/frontend/src/pages/main-page/components/about-modal/about-modal.tsx
@@ -39,7 +39,7 @@ import Confetti from 'react-confetti';
 import { ExternalLink } from '../../../../components/external-link/external-link';
 import { IexMenuItem } from '../../../../components/iex-menu-item/iex-menu-item';
 import { Link as RouterLink } from '../../../../components/link/link';
-import { AppSettings } from '../../../../models/generated/graphql';
+import type { AppSettings } from '../../../../models/generated/graphql';
 
 const icons = [
   {

--- a/packages/frontend/src/pages/main-page/components/footer/footer.tsx
+++ b/packages/frontend/src/pages/main-page/components/footer/footer.tsx
@@ -32,12 +32,8 @@ export const Footer = (props) => {
   const bgColor = useColorModeValue('unset', 'gray.700');
   const color = useColorModeValue('gray.700', 'gray.200');
 
-  let apolloSandboxLink;
-  if (window.location.origin === 'http://localhost:3000') {
-    apolloSandboxLink = 'http://localhost:3001/api/v1/graphql';
-  } else {
-    apolloSandboxLink = '/api/v1/graphql';
-  }
+  const apolloSandboxLink =
+    window.location.origin === 'http://localhost:3000' ? 'http://localhost:3001/api/v1/graphql' : '/api/v1/graphql';
 
   return (
     <HStack

--- a/packages/frontend/src/pages/main-page/components/footer/footer.tsx
+++ b/packages/frontend/src/pages/main-page/components/footer/footer.tsx
@@ -18,7 +18,7 @@ import { HStack, Icon, Link, Text, useColorModeValue } from '@chakra-ui/react';
 import { useSelector } from 'react-redux';
 
 import { iconFactory } from '../../../../shared/icon-factory';
-import { RootState } from '../../../../store/store';
+import type { RootState } from '../../../../store/store';
 
 const FooterItem = ({ children }) => (
   <HStack spacing="0.25rem" fontSize="xs" align="center">

--- a/packages/frontend/src/pages/main-page/components/global-errors/global-errors.tsx
+++ b/packages/frontend/src/pages/main-page/components/global-errors/global-errors.tsx
@@ -19,7 +19,7 @@ import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { appSlice } from '../../../../store/app.slice';
-import { RootState } from '../../../../store/store';
+import type { RootState } from '../../../../store/store';
 
 export const GlobalErrors = () => {
   const { globalErrorMessages } = useSelector((state: RootState) => state.app);

--- a/packages/frontend/src/pages/main-page/components/header/components/help-menu/help-menu.tsx
+++ b/packages/frontend/src/pages/main-page/components/header/components/help-menu/help-menu.tsx
@@ -21,7 +21,7 @@ import { IconButtonMenu } from '../../../../../../components/icon-button-menu/ic
 import { IexMenuItem } from '../../../../../../components/iex-menu-item/iex-menu-item';
 import { chatIcon } from '../../../../../../shared/chat-icon';
 import { iconFactory } from '../../../../../../shared/icon-factory';
-import { RootState } from '../../../../../../store/store';
+import type { RootState } from '../../../../../../store/store';
 import { AboutModal } from '../../../about-modal/about-modal';
 import { NewsDrawer } from '../news-drawer/news-drawer';
 

--- a/packages/frontend/src/pages/main-page/components/header/components/news-drawer/components/news-drawer-contents/news-drawer-contents.tsx
+++ b/packages/frontend/src/pages/main-page/components/header/components/news-drawer/components/news-drawer-contents/news-drawer-contents.tsx
@@ -27,7 +27,7 @@ import {
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { News } from '../../../../../../../../models/generated/graphql';
+import type { News } from '../../../../../../../../models/generated/graphql';
 import { useLikedBy } from '../../../../../../../../shared/useLikedBy';
 import { useNews } from '../../../../../../../../shared/useNews';
 import { appSlice } from '../../../../../../../../store/app.slice';

--- a/packages/frontend/src/pages/main-page/components/header/components/news-drawer/components/news-item/news-item.tsx
+++ b/packages/frontend/src/pages/main-page/components/header/components/news-drawer/components/news-item/news-item.tsx
@@ -16,14 +16,14 @@
 
 import { Box, Flex, Heading, List, ListItem, Text } from '@chakra-ui/react';
 import { DateTime } from 'luxon';
-import { Components } from 'react-markdown';
+import type { Components } from 'react-markdown';
 
 import { Card } from '../../../../../../../../components/card/card';
 import { LikeButton } from '../../../../../../../../components/like-button/like-button';
 import { LikedByTooltip } from '../../../../../../../../components/liked-by-tooltip/liked-by-tooltip';
 import { getDataAttributes } from '../../../../../../../../components/markdown-container/chakra-ui-renderer';
 import { MarkdownContainer } from '../../../../../../../../components/markdown-container/markdown-container';
-import { News, User } from '../../../../../../../../models/generated/graphql';
+import type { News, User } from '../../../../../../../../models/generated/graphql';
 import { formatDateIntl } from '../../../../../../../../shared/date-utils';
 
 const heading = ({ node, children, level, ...props }) => {

--- a/packages/frontend/src/pages/main-page/components/header/components/news-drawer/news-drawer.tsx
+++ b/packages/frontend/src/pages/main-page/components/header/components/news-drawer/news-drawer.tsx
@@ -21,7 +21,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { IexMenuItem } from '../../../../../../components/iex-menu-item/iex-menu-item';
 import { iconFactory } from '../../../../../../shared/icon-factory';
 import { appSlice } from '../../../../../../store/app.slice';
-import { RootState } from '../../../../../../store/store';
+import type { RootState } from '../../../../../../store/store';
 
 import { NewsDrawerContents } from './components/news-drawer-contents/news-drawer-contents';
 

--- a/packages/frontend/src/pages/main-page/components/header/components/user-menu/user-menu.tsx
+++ b/packages/frontend/src/pages/main-page/components/header/components/user-menu/user-menu.tsx
@@ -19,7 +19,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { IexMenuItem } from '../../../../../../components/iex-menu-item/iex-menu-item';
 import { iconFactory, iconFactoryAs } from '../../../../../../shared/icon-factory';
-import { RootState } from '../../../../../../store/store';
+import type { RootState } from '../../../../../../store/store';
 import { LoginState, userSlice } from '../../../../../../store/user.slice';
 
 export const UserMenu = () => {

--- a/packages/frontend/src/pages/main-page/components/user-health-check/user-health-check.tsx
+++ b/packages/frontend/src/pages/main-page/components/user-health-check/user-health-check.tsx
@@ -15,14 +15,15 @@
  */
 
 import { useBreakpointValue } from '@chakra-ui/media-query';
-import { Alert as ChakraAlert, AlertIcon, Badge, Box, BoxProps, Button, Stack, Text } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Alert as ChakraAlert, AlertIcon, Badge, Box, Button, Stack, Text } from '@chakra-ui/react';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { Alert } from '../../../../components/alert/alert';
 import { ExternalLink } from '../../../../components/external-link/external-link';
 import { Link as RouterLink } from '../../../../components/link/link';
-import { RootState } from '../../../../store/store';
+import type { RootState } from '../../../../store/store';
 import { executeHealthCheck } from '../../../../store/user.slice';
 
 const HealthCheckAlert = ({ children, allowRecheck = true }) => {

--- a/packages/frontend/src/pages/profile-page/components/user-profile/components/user-about/user-about.tsx
+++ b/packages/frontend/src/pages/profile-page/components/user-profile/components/user-about/user-about.tsx
@@ -18,7 +18,7 @@ import { Stack, Stat, StatLabel, StatNumber, Text } from '@chakra-ui/react';
 
 import { Card } from '../../../../../../components/card/card';
 import { MarkdownContainer } from '../../../../../../components/markdown-container/markdown-container';
-import { User } from '../../../../../../models/generated/graphql';
+import type { User } from '../../../../../../models/generated/graphql';
 
 interface Props {
   user: User;

--- a/packages/frontend/src/pages/profile-page/components/user-profile/components/user-activity/user-activity.tsx
+++ b/packages/frontend/src/pages/profile-page/components/user-profile/components/user-activity/user-activity.tsx
@@ -15,7 +15,7 @@
  */
 
 import { FetchActivityList } from '../../../../../../components/activity-list/fetch-activity-list';
-import { User } from '../../../../../../models/generated/graphql';
+import type { User } from '../../../../../../models/generated/graphql';
 
 interface Props {
   user: User;

--- a/packages/frontend/src/pages/profile-page/components/user-profile/components/user-drafts/user-drafts.tsx
+++ b/packages/frontend/src/pages/profile-page/components/user-profile/components/user-drafts/user-drafts.tsx
@@ -28,7 +28,6 @@ import {
   VStack
 } from '@chakra-ui/react';
 import { useState } from 'react';
-
 import { gql, useMutation, useQuery } from 'urql';
 
 import { Alert } from '../../../../../../components/alert/alert';

--- a/packages/frontend/src/pages/profile-page/components/user-profile/components/user-drafts/user-drafts.tsx
+++ b/packages/frontend/src/pages/profile-page/components/user-profile/components/user-drafts/user-drafts.tsx
@@ -28,6 +28,7 @@ import {
   VStack
 } from '@chakra-ui/react';
 import { useState } from 'react';
+
 import { gql, useMutation, useQuery } from 'urql';
 
 import { Alert } from '../../../../../../components/alert/alert';

--- a/packages/frontend/src/pages/profile-page/components/user-profile/components/user-drafts/user-drafts.tsx
+++ b/packages/frontend/src/pages/profile-page/components/user-profile/components/user-drafts/user-drafts.tsx
@@ -35,7 +35,7 @@ import { Alert } from '../../../../../../components/alert/alert';
 import { Card } from '../../../../../../components/card/card';
 import { ItemTypeIcon } from '../../../../../../components/item-type-icon/item-type-icon';
 import { Link } from '../../../../../../components/link/link';
-import { Draft, Insight, User } from '../../../../../../models/generated/graphql';
+import type { Draft, Insight, User } from '../../../../../../models/generated/graphql';
 import { formatRelativeIntl } from '../../../../../../shared/date-utils';
 import { iconFactory } from '../../../../../../shared/icon-factory';
 

--- a/packages/frontend/src/pages/profile-page/components/user-profile/components/user-insights/user-insights.tsx
+++ b/packages/frontend/src/pages/profile-page/components/user-profile/components/user-insights/user-insights.tsx
@@ -19,9 +19,9 @@ import { useState } from 'react';
 
 import { IconButtonMenu } from '../../../../../../components/icon-button-menu/icon-button-menu';
 import { InsightList } from '../../../../../../components/insight-list/insight-list';
-import { InsightConnection, User } from '../../../../../../models/generated/graphql';
+import type { InsightConnection, User } from '../../../../../../models/generated/graphql';
 import { iconFactory } from '../../../../../../shared/icon-factory';
-import { SearchOptions } from '../../../../../../store/search.slice';
+import type { SearchOptions } from '../../../../../../store/search.slice';
 
 interface Props {
   user: User;

--- a/packages/frontend/src/pages/profile-page/components/user-profile/components/user-sidebar/user-sidebar.tsx
+++ b/packages/frontend/src/pages/profile-page/components/user-profile/components/user-sidebar/user-sidebar.tsx
@@ -33,11 +33,11 @@ import { useSelector } from 'react-redux';
 import { ExternalLink } from '../../../../../../components/external-link/external-link';
 import { Link } from '../../../../../../components/link/link';
 import { TextWithIcon } from '../../../../../../components/text-with-icon/text-with-icon';
-import { User } from '../../../../../../models/generated/graphql';
+import type { User } from '../../../../../../models/generated/graphql';
 import { chatIcon } from '../../../../../../shared/chat-icon';
 import { formatDateIntl } from '../../../../../../shared/date-utils';
 import { iconFactory } from '../../../../../../shared/icon-factory';
-import { RootState } from '../../../../../../store/store';
+import type { RootState } from '../../../../../../store/store';
 
 interface Props {
   user: User;

--- a/packages/frontend/src/pages/profile-page/components/user-profile/user-profile.tsx
+++ b/packages/frontend/src/pages/profile-page/components/user-profile/user-profile.tsx
@@ -19,7 +19,7 @@ import { useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { User } from '../../../../models/generated/graphql';
+import type { User } from '../../../../models/generated/graphql';
 import { iconFactory } from '../../../../shared/icon-factory';
 
 import { UserAbout } from './components/user-about/user-about';

--- a/packages/frontend/src/pages/profile-page/profile-page.tsx
+++ b/packages/frontend/src/pages/profile-page/profile-page.tsx
@@ -19,7 +19,7 @@ import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 
 import { useUser } from '../../shared/useUser';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 import { ProfileNotFoundPage } from '../profile-not-found-page/profile-not-found-page';
 
 import { UserProfile } from './components/user-profile/user-profile';

--- a/packages/frontend/src/pages/search-page/components/filter-sidebar/components/filter-stack/filter-stack.tsx
+++ b/packages/frontend/src/pages/search-page/components/filter-sidebar/components/filter-stack/filter-stack.tsx
@@ -18,8 +18,8 @@ import { Checkbox } from '@chakra-ui/react';
 import CreatableSelect from 'react-select/creatable';
 
 import { SidebarStack } from '../../../../../../components/sidebar-stack/sidebar-stack';
-import { UniqueValue } from '../../../../../../models/generated/graphql';
-import { SearchTerm } from '../../../../../../shared/search';
+import type { UniqueValue } from '../../../../../../models/generated/graphql';
+import type { SearchTerm } from '../../../../../../shared/search';
 
 interface Props {
   filterKey: string;

--- a/packages/frontend/src/pages/search-page/components/filter-sidebar/components/item-type-stack/item-type-stack.tsx
+++ b/packages/frontend/src/pages/search-page/components/filter-sidebar/components/item-type-stack/item-type-stack.tsx
@@ -17,7 +17,8 @@
 import { Checkbox } from '@chakra-ui/react';
 
 import { SidebarStack } from '../../../../../../components/sidebar-stack/sidebar-stack';
-import { SearchClause, SearchMultiTerm, SearchTerm } from '../../../../../../shared/search';
+import type { SearchClause } from '../../../../../../shared/search';
+import { SearchMultiTerm, SearchTerm } from '../../../../../../shared/search';
 
 const itemTypes = [
   { value: 'insight', label: 'Insight' },

--- a/packages/frontend/src/pages/search-page/components/filter-sidebar/filter-sidebar.tsx
+++ b/packages/frontend/src/pages/search-page/components/filter-sidebar/filter-sidebar.tsx
@@ -20,7 +20,6 @@ import type { ReactElement } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
-
 import { gql, useQuery } from 'urql';
 
 import type { AutocompleteFilterSidebarQuery, AutocompleteResults } from '../../../../models/generated/graphql';

--- a/packages/frontend/src/pages/search-page/components/filter-sidebar/filter-sidebar.tsx
+++ b/packages/frontend/src/pages/search-page/components/filter-sidebar/filter-sidebar.tsx
@@ -96,7 +96,7 @@ export const FilterSidebar = ({ suggestedFilters, ...boxProps }: Props & BoxProp
         if (isActuallyFiltered !== isFiltered) {
           dispatch(searchSlice.actions.setIsFiltered(isActuallyFiltered));
         }
-      } catch (e: any) {
+      } catch {
         // If there's a parsing error, it will be detected
         // server-side and displayed elsewhere.
         // Do nothing.

--- a/packages/frontend/src/pages/search-page/components/filter-sidebar/filter-sidebar.tsx
+++ b/packages/frontend/src/pages/search-page/components/filter-sidebar/filter-sidebar.tsx
@@ -188,13 +188,8 @@ export const FilterSidebar = ({ suggestedFilters, ...boxProps }: Props & BoxProp
 
       dispatch(searchSlice.actions.setQuery(toSearchQuery(searchClauses)));
     } else {
-      let newClause: SearchClause;
-
-      if (values.length === 1) {
-        newClause = new SearchTerm(key, values[0]);
-      } else {
-        newClause = new SearchMultiTerm(key, values);
-      }
+      const newClause: SearchClause =
+        values.length === 1 ? new SearchTerm(key, values[0]) : new SearchMultiTerm(key, values);
 
       dispatch(searchSlice.actions.setQuery(`${query} ${newClause.toString()}`.trim()));
     }

--- a/packages/frontend/src/pages/search-page/components/filter-sidebar/filter-sidebar.tsx
+++ b/packages/frontend/src/pages/search-page/components/filter-sidebar/filter-sidebar.tsx
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-import { BoxProps, StackDivider, VStack } from '@chakra-ui/react';
-import { ReactElement, useEffect, useRef, useState } from 'react';
+import type { BoxProps } from '@chakra-ui/react';
+import { StackDivider, VStack } from '@chakra-ui/react';
+import type { ReactElement } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 
 import { gql, useQuery } from 'urql';
 
-import { AutocompleteFilterSidebarQuery, AutocompleteResults } from '../../../../models/generated/graphql';
+import type { AutocompleteFilterSidebarQuery, AutocompleteResults } from '../../../../models/generated/graphql';
+import type { SearchClause } from '../../../../shared/search';
 import {
   parseSearchQuery,
-  SearchClause,
   SearchCompoundRange,
   SearchMultiTerm,
   SearchRange,
@@ -32,7 +34,7 @@ import {
   toSearchQuery
 } from '../../../../shared/search';
 import { searchSlice } from '../../../../store/search.slice';
-import { RootState } from '../../../../store/store';
+import type { RootState } from '../../../../store/store';
 
 import { DateStack } from './components/date-stack/date-stack';
 import { FilterStack } from './components/filter-stack/filter-stack';

--- a/packages/frontend/src/pages/search-page/components/filter-sidebar/filter-sidebar.tsx
+++ b/packages/frontend/src/pages/search-page/components/filter-sidebar/filter-sidebar.tsx
@@ -18,6 +18,7 @@ import { BoxProps, StackDivider, VStack } from '@chakra-ui/react';
 import { ReactElement, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
+
 import { gql, useQuery } from 'urql';
 
 import { AutocompleteFilterSidebarQuery, AutocompleteResults } from '../../../../models/generated/graphql';

--- a/packages/frontend/src/pages/search-page/components/search-bar/search-bar.tsx
+++ b/packages/frontend/src/pages/search-page/components/search-bar/search-bar.tsx
@@ -26,14 +26,15 @@ import {
   MenuOptionGroup,
   Tooltip
 } from '@chakra-ui/react';
-import { ReactElement, useEffect, useRef, useState } from 'react';
+import type { ReactElement } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 
 import { iconFactoryAs } from '../../../../shared/icon-factory';
 import { useDebounce } from '../../../../shared/useDebounce';
 import { searchSlice } from '../../../../store/search.slice';
-import { RootState } from '../../../../store/store';
+import type { RootState } from '../../../../store/store';
 import { SearchBox } from '../search-box/search-box';
 
 const availableSortFields = [

--- a/packages/frontend/src/pages/search-page/components/search-box/search-box.tsx
+++ b/packages/frontend/src/pages/search-page/components/search-box/search-box.tsx
@@ -15,7 +15,7 @@
  */
 
 import { IconButton, Input, InputGroup, InputLeftElement, InputRightElement, Tooltip } from '@chakra-ui/react';
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 
 import { iconFactoryAs } from '../../../../shared/icon-factory';
 

--- a/packages/frontend/src/pages/search-page/search-page.tsx
+++ b/packages/frontend/src/pages/search-page/search-page.tsx
@@ -27,7 +27,7 @@ import { generateSearchUrl } from '../../shared/search-url';
 import { useDebounce } from '../../shared/useDebounce';
 import { useSearch } from '../../shared/useSearch';
 import { searchSlice } from '../../store/search.slice';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 
 import { FilterSidebar } from './components/filter-sidebar/filter-sidebar';
 import { SearchBar } from './components/search-bar/search-bar';

--- a/packages/frontend/src/pages/settings-page/components/github-settings/github-settings.tsx
+++ b/packages/frontend/src/pages/settings-page/components/github-settings/github-settings.tsx
@@ -65,7 +65,7 @@ const GitHubPersonalAccessTokenInput = ({ name, defaultValue, form }) => {
           placeholder="GitHub Personal Access Token"
           type={show ? 'text' : 'password'}
           defaultValue={defaultValue}
-          {...register(name, { required: true, maxLength: 40, pattern: /^[A-Za-z0-9_]{40}$/ })}
+          {...register(name, { required: true, maxLength: 40, pattern: /^\w{40}$/ })}
           errorBorderColor="red.300"
           onChange={(e) => (e.target.value = e.target.value.trim())}
         />

--- a/packages/frontend/src/pages/settings-page/components/github-settings/github-settings.tsx
+++ b/packages/frontend/src/pages/settings-page/components/github-settings/github-settings.tsx
@@ -34,7 +34,7 @@ import { useForm } from 'react-hook-form';
 import { Alert } from '../../../../components/alert/alert';
 import { Card } from '../../../../components/card/card';
 import { FormLabel } from '../../../../components/form-label/form-label';
-import { User } from '../../../../models/generated/graphql';
+import type { User } from '../../../../models/generated/graphql';
 import { formatFormError } from '../../../../shared/form-utils';
 import { UserHealthCheck } from '../../../main-page/components/user-health-check/user-health-check';
 

--- a/packages/frontend/src/pages/settings-page/components/github-settings/github-token-info.tsx
+++ b/packages/frontend/src/pages/settings-page/components/github-settings/github-token-info.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import type { ButtonProps } from '@chakra-ui/react';
 import {
   Button,
-  ButtonProps,
   IconButton,
   ListItem,
   Modal,
@@ -36,7 +36,7 @@ import { useSelector } from 'react-redux';
 
 import { ExternalLink } from '../../../../components/external-link/external-link';
 import { iconFactoryAs } from '../../../../shared/icon-factory';
-import { RootState } from '../../../../store/store';
+import type { RootState } from '../../../../store/store';
 
 export const GithubTokenInfo = (props: ButtonProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure();

--- a/packages/frontend/src/pages/settings-page/components/insights-settings/insights-settings.tsx
+++ b/packages/frontend/src/pages/settings-page/components/insights-settings/insights-settings.tsx
@@ -17,6 +17,7 @@
 import { Box, Button, Flex, FormControl, FormHelperText } from '@chakra-ui/react';
 import { Controller, useForm } from 'react-hook-form';
 import Select from 'react-select';
+
 import { gql, useQuery } from 'urql';
 
 import { Alert } from '../../../../components/alert/alert';

--- a/packages/frontend/src/pages/settings-page/components/insights-settings/insights-settings.tsx
+++ b/packages/frontend/src/pages/settings-page/components/insights-settings/insights-settings.tsx
@@ -23,7 +23,7 @@ import { gql, useQuery } from 'urql';
 import { Alert } from '../../../../components/alert/alert';
 import { Card } from '../../../../components/card/card';
 import { FormLabel } from '../../../../components/form-label/form-label';
-import { TemplatesQuery, User } from '../../../../models/generated/graphql';
+import type { TemplatesQuery, User } from '../../../../models/generated/graphql';
 
 const TEMPLATES_QUERY = gql`
   query Templates {

--- a/packages/frontend/src/pages/settings-page/components/insights-settings/insights-settings.tsx
+++ b/packages/frontend/src/pages/settings-page/components/insights-settings/insights-settings.tsx
@@ -17,7 +17,6 @@
 import { Box, Button, Flex, FormControl, FormHelperText } from '@chakra-ui/react';
 import { Controller, useForm } from 'react-hook-form';
 import Select from 'react-select';
-
 import { gql, useQuery } from 'urql';
 
 import { Alert } from '../../../../components/alert/alert';

--- a/packages/frontend/src/pages/settings-page/components/profile-settings/profile-settings.tsx
+++ b/packages/frontend/src/pages/settings-page/components/profile-settings/profile-settings.tsx
@@ -39,7 +39,6 @@ import { Controller, useForm } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 import CreatableSelect from 'react-select/creatable';
 import titleize from 'titleize';
-
 import { gql, useQuery } from 'urql';
 
 import { Alert } from '../../../../components/alert/alert';

--- a/packages/frontend/src/pages/settings-page/components/profile-settings/profile-settings.tsx
+++ b/packages/frontend/src/pages/settings-page/components/profile-settings/profile-settings.tsx
@@ -140,7 +140,7 @@ export const ProfileSettings = ({ user, onSubmit, isSubmitting }: Props) => {
 
   const onDropAvatar = useCallback(
     async (acceptedFiles: any[]) => {
-      if (acceptedFiles.length < 1) {
+      if (acceptedFiles.length === 0) {
         return;
       }
 

--- a/packages/frontend/src/pages/settings-page/components/profile-settings/profile-settings.tsx
+++ b/packages/frontend/src/pages/settings-page/components/profile-settings/profile-settings.tsx
@@ -204,7 +204,7 @@ export const ProfileSettings = ({ user, onSubmit, isSubmitting }: Props) => {
                 placeholder="User Name"
                 defaultValue={user.userName}
                 errorBorderColor="red.300"
-                {...register('userName', { required: true, pattern: /^[A-Za-z0-9]+$/ })}
+                {...register('userName', { required: true, pattern: /^[\dA-Za-z]+$/ })}
                 onChange={(e) => (e.target.value = e.target.value.trim().toLowerCase())}
               />
               <FormHelperText>Your user name appears in your profile URL and can be used for @mentions.</FormHelperText>

--- a/packages/frontend/src/pages/settings-page/components/profile-settings/profile-settings.tsx
+++ b/packages/frontend/src/pages/settings-page/components/profile-settings/profile-settings.tsx
@@ -39,6 +39,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 import CreatableSelect from 'react-select/creatable';
 import titleize from 'titleize';
+
 import { gql, useQuery } from 'urql';
 
 import { Alert } from '../../../../components/alert/alert';

--- a/packages/frontend/src/pages/settings-page/components/profile-settings/profile-settings.tsx
+++ b/packages/frontend/src/pages/settings-page/components/profile-settings/profile-settings.tsx
@@ -47,7 +47,7 @@ import { Card } from '../../../../components/card/card';
 import { FileUploadArea } from '../../../../components/file-upload-area/file-upload-area';
 import { FormLabel } from '../../../../components/form-label/form-label';
 import { MarkdownSplitEditor } from '../../../../components/markdown-split-editor/markdown-split-editor';
-import {
+import type {
   AutocompleteProfileQuery,
   AvatarUploadResult,
   UpdateUserInput,
@@ -56,7 +56,7 @@ import {
 import { chatIcon } from '../../../../shared/chat-icon';
 import { formatFormError } from '../../../../shared/form-utils';
 import { iconFactoryAs } from '../../../../shared/icon-factory';
-import { RootState } from '../../../../store/store';
+import type { RootState } from '../../../../store/store';
 import { urqlClient } from '../../../../urql';
 
 const AUTOCOMPLETE_QUERY = gql`

--- a/packages/frontend/src/pages/settings-page/components/system-settings/system-settings.tsx
+++ b/packages/frontend/src/pages/settings-page/components/system-settings/system-settings.tsx
@@ -21,7 +21,7 @@ import Select from 'react-select';
 import { Alert } from '../../../../components/alert/alert';
 import { Card } from '../../../../components/card/card';
 import { FormLabel } from '../../../../components/form-label/form-label';
-import { User } from '../../../../models/generated/graphql';
+import type { User } from '../../../../models/generated/graphql';
 import { availableLocales } from '../../../../shared/date-utils';
 
 interface Props {

--- a/packages/frontend/src/pages/settings-page/settings-page.tsx
+++ b/packages/frontend/src/pages/settings-page/settings-page.tsx
@@ -19,7 +19,6 @@ import { Helmet } from 'react-helmet';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 import { Navigate, Route, Routes } from 'react-router-dom';
-
 import { useQuery, useMutation, gql } from 'urql';
 
 import { Alert } from '../../components/alert/alert';

--- a/packages/frontend/src/pages/settings-page/settings-page.tsx
+++ b/packages/frontend/src/pages/settings-page/settings-page.tsx
@@ -24,9 +24,10 @@ import { useQuery, useMutation, gql } from 'urql';
 
 import { Alert } from '../../components/alert/alert';
 import { Link } from '../../components/link/link';
-import { SettingsSection, SettingsSidebar } from '../../components/settings-sidebar/settings-sidebar';
+import type { SettingsSection } from '../../components/settings-sidebar/settings-sidebar';
+import { SettingsSidebar } from '../../components/settings-sidebar/settings-sidebar';
 import { iconFactory } from '../../shared/icon-factory';
-import { RootState } from '../../store/store';
+import type { RootState } from '../../store/store';
 import { executeHealthCheck, userSlice } from '../../store/user.slice';
 import { ErrorPage } from '../error-page/error-page';
 

--- a/packages/frontend/src/pages/settings-page/settings-page.tsx
+++ b/packages/frontend/src/pages/settings-page/settings-page.tsx
@@ -19,6 +19,7 @@ import { Helmet } from 'react-helmet';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 import { Navigate, Route, Routes } from 'react-router-dom';
+
 import { useQuery, useMutation, gql } from 'urql';
 
 import { Alert } from '../../components/alert/alert';

--- a/packages/frontend/src/shared/date-utils.ts
+++ b/packages/frontend/src/shared/date-utils.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { DateTime, DateTimeFormatOptions, ToRelativeOptions } from 'luxon';
+import type { DateTimeFormatOptions, ToRelativeOptions } from 'luxon';
+import { DateTime } from 'luxon';
 
 import { store } from '../store/store';
 

--- a/packages/frontend/src/shared/date-utils.ts
+++ b/packages/frontend/src/shared/date-utils.ts
@@ -56,18 +56,12 @@ export function formatDateIntl(
     locale = store?.getState().user.userInfo?.locale;
   }
   if (locale == null) {
-    if (typeof format == 'string') {
-      return dt.toFormat(format);
-    } else {
-      return dt.toLocaleString(format);
-    }
+    return typeof format == 'string' ? dt.toFormat(format) : dt.toLocaleString(format);
   }
 
-  if (typeof format == 'string') {
-    return dt.setLocale(locale).toFormat(format);
-  } else {
-    return dt.setLocale(locale).toLocaleString(format);
-  }
+  return typeof format == 'string'
+    ? dt.setLocale(locale).toFormat(format)
+    : dt.setLocale(locale).toLocaleString(format);
 }
 
 export function formatRelativeIntl(
@@ -75,13 +69,7 @@ export function formatRelativeIntl(
   options: ToRelativeOptions = {},
   locale?: string
 ): string | null {
-  let dt: DateTime;
-
-  if (typeof dateTimeOrString == 'string') {
-    dt = DateTime.fromISO(dateTimeOrString);
-  } else {
-    dt = dateTimeOrString;
-  }
+  const dt = typeof dateTimeOrString == 'string' ? DateTime.fromISO(dateTimeOrString) : dateTimeOrString;
 
   if (locale == null) {
     locale = store?.getState().user.userInfo?.locale;

--- a/packages/frontend/src/shared/destring.test.ts
+++ b/packages/frontend/src/shared/destring.test.ts
@@ -57,7 +57,7 @@ describe('destring', () => {
     expect(destring('-2.45e10')).toEqual(-2.45e10);
   });
   test('-infinity', () => {
-    expect(destring('-infinity')).toEqual(-Infinity);
+    expect(destring('-infinity')).toEqual(Number.NEGATIVE_INFINITY);
   });
   test('unstyled', () => {
     expect(destring('unstyled')).toEqual('unstyled');

--- a/packages/frontend/src/shared/destring.ts
+++ b/packages/frontend/src/shared/destring.ts
@@ -41,13 +41,13 @@ export function destring(value: string | Array<any> | Record<string, string>): a
     return Number.parseInt(value, 2);
   }
   // try parse int
-  if (value.match(/^-?\d+$/)) {
+  if (/^-?\d+$/.test(value)) {
     return Number.parseInt(value, 10);
   }
-  if (value.match(/^-?\d*\.\d+$/)) {
+  if (/^-?\d*\.\d+$/.test(value)) {
     return Number.parseFloat(value);
   }
-  if (value.match(/^-?\d*\.\d*(e[+-]?\d+)?$/)) {
+  if (/^-?\d*\.\d*(e[+-]?\d+)?$/.test(value)) {
     return Number.parseFloat(value);
   }
 

--- a/packages/frontend/src/shared/destring.ts
+++ b/packages/frontend/src/shared/destring.ts
@@ -20,35 +20,35 @@ export function destring(value: string | Array<any> | Record<string, string>): a
     return false;
   }
   if (lowerValue === 'nan') {
-    return NaN;
+    return Number.NaN;
   }
   if (lowerValue === '-nan') {
-    return -NaN;
+    return -Number.NaN;
   }
   if (lowerValue === 'infinity') {
-    return Infinity;
+    return Number.POSITIVE_INFINITY;
   }
   if (lowerValue === '-infinity') {
-    return -Infinity;
+    return Number.NEGATIVE_INFINITY;
   }
   if (lowerValue.startsWith('0x')) {
-    return parseInt(value, 16);
+    return Number.parseInt(value, 16);
   }
   if (lowerValue.startsWith('0o')) {
-    return parseInt(value, 8);
+    return Number.parseInt(value, 8);
   }
   if (lowerValue.startsWith('0b')) {
-    return parseInt(value, 2);
+    return Number.parseInt(value, 2);
   }
   // try parse int
   if (value.match(/^-?\d+$/)) {
-    return parseInt(value, 10);
+    return Number.parseInt(value, 10);
   }
   if (value.match(/^-?\d*\.\d+$/)) {
-    return parseFloat(value);
+    return Number.parseFloat(value);
   }
   if (value.match(/^-?\d*\.\d*(e[+-]?\d+)?$/)) {
-    return parseFloat(value);
+    return Number.parseFloat(value);
   }
 
   return value;

--- a/packages/frontend/src/shared/file-icon-factory.tsx
+++ b/packages/frontend/src/shared/file-icon-factory.tsx
@@ -15,8 +15,8 @@
  */
 
 import { Icon, Image } from '@chakra-ui/react';
-import { ReactElement } from 'react';
-import { IconType } from 'react-icons';
+import type { ReactElement } from 'react';
+import type { IconType } from 'react-icons';
 import {
   AiFillFolder,
   AiFillFolderOpen,

--- a/packages/frontend/src/shared/file-tree.test.ts
+++ b/packages/frontend/src/shared/file-tree.test.ts
@@ -16,7 +16,7 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import { InsightFile, InsightFileAction, InsightFolder } from '../models/file-tree';
+import type { InsightFile, InsightFileAction, InsightFolder } from '../models/file-tree';
 
 import { convertFilesIntoTree, InsightFileTree, isFile, isFolder } from './file-tree';
 

--- a/packages/frontend/src/shared/file-tree.ts
+++ b/packages/frontend/src/shared/file-tree.ts
@@ -17,7 +17,7 @@
 import { freeze, produce } from 'immer';
 import { nanoid } from 'nanoid';
 
-import { FileOrFolder, InsightFile, InsightFileAction, InsightFolder } from '../models/file-tree';
+import type { FileOrFolder, InsightFile, InsightFileAction, InsightFolder } from '../models/file-tree';
 
 const PATH_SEPARATOR = '/';
 

--- a/packages/frontend/src/shared/file-tree.ts
+++ b/packages/frontend/src/shared/file-tree.ts
@@ -122,7 +122,9 @@ export class InsightFileTree {
         if (updatedItem.name && item.name !== updatedItem.name) {
           if (item.path.includes(PATH_SEPARATOR)) {
             item.path =
-              item.path.substring(0, item.path.lastIndexOf(PATH_SEPARATOR)) + PATH_SEPARATOR + updatedItem.name;
+              item.path.slice(0, Math.max(0, item.path.lastIndexOf(PATH_SEPARATOR))) +
+              PATH_SEPARATOR +
+              updatedItem.name;
           } else {
             item.path = updatedItem.name;
           }

--- a/packages/frontend/src/shared/form-utils.ts
+++ b/packages/frontend/src/shared/form-utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FieldError } from 'react-hook-form';
+import type { FieldError } from 'react-hook-form';
 
 export const formatFormError = (
   error: FieldError | undefined,

--- a/packages/frontend/src/shared/gradient.ts
+++ b/packages/frontend/src/shared/gradient.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Insight } from '../models/generated/graphql';
+import type { Insight } from '../models/generated/graphql';
 
 import { hashCode } from './hash';
 import { getRandomInt } from './random';

--- a/packages/frontend/src/shared/hash.ts
+++ b/packages/frontend/src/shared/hash.ts
@@ -22,7 +22,7 @@ export const hashCode = (str: string): number => {
     chr = str.codePointAt(i);
     if (chr !== undefined) {
       hash = (hash << 5) - hash + chr;
-      hash |= 0;
+      hash = Math.trunc(hash);
     }
   }
   return hash;

--- a/packages/frontend/src/shared/hash.ts
+++ b/packages/frontend/src/shared/hash.ts
@@ -17,11 +17,13 @@
 export const hashCode = (str: string): number => {
   let hash = 0,
     i: number,
-    chr: number;
+    chr: number | undefined;
   for (i = 0; i < str.length; i++) {
-    chr = str.charCodeAt(i);
-    hash = (hash << 5) - hash + chr;
-    hash |= 0;
+    chr = str.codePointAt(i);
+    if (chr !== undefined) {
+      hash = (hash << 5) - hash + chr;
+      hash |= 0;
+    }
   }
   return hash;
 };

--- a/packages/frontend/src/shared/icon-factory.tsx
+++ b/packages/frontend/src/shared/icon-factory.tsx
@@ -15,8 +15,8 @@
  */
 
 import { Icon } from '@chakra-ui/react';
-import { ReactElement } from 'react';
-import { IconType } from 'react-icons';
+import type { ReactElement } from 'react';
+import type { IconType } from 'react-icons';
 import {
   AiFillEdit,
   AiFillGift,

--- a/packages/frontend/src/shared/insight-utils.ts
+++ b/packages/frontend/src/shared/insight-utils.ts
@@ -1,4 +1,4 @@
-import { InsightLink } from '../models/generated/graphql';
+import type { InsightLink } from '../models/generated/graphql';
 
 /**
  * Group links into sections, with a default section of `Links.

--- a/packages/frontend/src/shared/json.ts
+++ b/packages/frontend/src/shared/json.ts
@@ -16,5 +16,5 @@
 
 export const looseJsonParse = (jsonString: string) => {
   // eslint-disable-next-line no-new-func
-  return Function('"use strict";return (' + jsonString + ')')();
+  return new Function('"use strict";return (' + jsonString + ')')();
 };

--- a/packages/frontend/src/shared/lines.ts
+++ b/packages/frontend/src/shared/lines.ts
@@ -62,13 +62,7 @@ export function parseLineFilter(lineFilter: string): LineSlice[] {
       let end = start + 1;
 
       if (parts.length === 2) {
-        if (parts[1] === '') {
-          end = Number.POSITIVE_INFINITY;
-        } else {
-          // Don't subtract one because `.slice()` is end-exclusive and this is inclusive.
-          // Works for both positive and negative variations.
-          end = Number.parseInt(parts[1]);
-        }
+        end = parts[1] === '' ? Number.POSITIVE_INFINITY : Number.parseInt(parts[1]);
       }
 
       return { start, end };

--- a/packages/frontend/src/shared/lines.ts
+++ b/packages/frontend/src/shared/lines.ts
@@ -58,16 +58,16 @@ export function parseLineFilter(lineFilter: string): LineSlice[] {
         return undefined;
       }
 
-      const start = parseInt(parts[0]) - 1;
+      const start = Number.parseInt(parts[0]) - 1;
       let end = start + 1;
 
       if (parts.length === 2) {
         if (parts[1] === '') {
-          end = Infinity;
+          end = Number.POSITIVE_INFINITY;
         } else {
           // Don't subtract one because `.slice()` is end-exclusive and this is inclusive.
           // Works for both positive and negative variations.
-          end = parseInt(parts[1]);
+          end = Number.parseInt(parts[1]);
         }
       }
 

--- a/packages/frontend/src/shared/remark/generic-attrs.ts
+++ b/packages/frontend/src/shared/remark/generic-attrs.ts
@@ -29,7 +29,7 @@ export class KeyValueAttribute implements Attribute {
 
 const lang = Parsimmon.createLanguage({
   Word: () => {
-    return Parsimmon.regexp(/[^=\s]+/i);
+    return Parsimmon.regexp(/[^\s=]+/i);
   },
   String: () => {
     // One of possible quotes, then sequence of anything

--- a/packages/frontend/src/shared/remark/remark-code-plus.ts
+++ b/packages/frontend/src/shared/remark/remark-code-plus.ts
@@ -49,7 +49,7 @@ export const remarkCodePlus = ({ baseUrl = '', transformAssetUri }: Props) => {
       };
 
       // Parse out attributes (if any)
-      const attrs = (node.meta || node.lang || '').match(/\{(.*)\}/);
+      const attrs = (node.meta || node.lang || '').match(/{(.*)}/);
 
       if (attrs !== null && attrs.length === 2) {
         const attributes = parseAttributes(attrs[1]);

--- a/packages/frontend/src/shared/remark/remark-mentions.ts
+++ b/packages/frontend/src/shared/remark/remark-mentions.ts
@@ -16,7 +16,7 @@
 
 import { findAndReplace } from 'mdast-util-find-and-replace';
 
-const mentionRegex = /@([A-Z0-9_]+)?/gi;
+const mentionRegex = /@(\w+)?/gi;
 
 const replaceMention = (match: string, username: string): any => {
   return {

--- a/packages/frontend/src/shared/search-url.ts
+++ b/packages/frontend/src/shared/search-url.ts
@@ -28,9 +28,5 @@ export const generateSearchUrl = (query: string | undefined, sort: Sort | undefi
     }
   }
 
-  if (searchParams.length > 0) {
-    return `${path}?${searchParams.join('&')}`;
-  } else {
-    return path;
-  }
+  return searchParams.length > 0 ? `${path}?${searchParams.join('&')}` : path;
 };

--- a/packages/frontend/src/shared/search-url.ts
+++ b/packages/frontend/src/shared/search-url.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Sort } from '../models/generated/graphql';
+import type { Sort } from '../models/generated/graphql';
 
 export const generateSearchUrl = (query: string | undefined, sort: Sort | undefined) => {
   const path = `/${encodeURIComponent(query || '')}`;

--- a/packages/frontend/src/shared/search.ts
+++ b/packages/frontend/src/shared/search.ts
@@ -274,13 +274,13 @@ export class SearchCompoundRange implements SearchClause {
 //
 const lang = Parsimmon.createLanguage({
   Word: () => {
-    return Parsimmon.regexp(/[^:\s]+/i);
+    return Parsimmon.regexp(/[^\s:]+/i);
   },
   CompoundRangeWord: () => {
-    return Parsimmon.regexp(/[^[\]:\s]+/i).fallback('');
+    return Parsimmon.regexp(/[^\s:[\]]+/i).fallback('');
   },
   MultiTermWord: () => {
-    return Parsimmon.regexp(/[^{}:,\s]+/i).fallback('');
+    return Parsimmon.regexp(/[^\s,:{}]+/i).fallback('');
   },
   String: () => {
     // One of possible quotes, then sequence of anything
@@ -332,7 +332,7 @@ const lang = Parsimmon.createLanguage({
     return Parsimmon.seq(
       r.Word,
       r.FilterSeparator.then(
-        Parsimmon.lookahead(/\{(.*)\}/).then(
+        Parsimmon.lookahead(/{(.*)}/).then(
           Parsimmon.alt(r.String, r.MultiTermWord.fallback(''))
             .trim(optWhitespace)
             .sepBy(Parsimmon.string(',').trim(optWhitespace))
@@ -357,7 +357,7 @@ const lang = Parsimmon.createLanguage({
     return Parsimmon.seq(
       r.Word,
       r.FilterSeparator.then(
-        Parsimmon.lookahead(/\[(.*)\]/).then(
+        Parsimmon.lookahead(/\[(.*)]/).then(
           Parsimmon.seq(r.CompoundRangeWord, Parsimmon.string('to').trim(optWhitespace).then(r.CompoundRangeWord)).wrap(
             Parsimmon.string('['),
             Parsimmon.string(']')

--- a/packages/frontend/src/shared/search.ts
+++ b/packages/frontend/src/shared/search.ts
@@ -167,11 +167,7 @@ export class SearchTerm implements SearchClause {
       case 'tag':
         return `#${this.value}`;
       default:
-        if (this.value.includes(' ')) {
-          return `${this.key}:"${this.value}"`;
-        } else {
-          return `${this.key}:${this.value}`;
-        }
+        return this.value.includes(' ') ? `${this.key}:"${this.value}"` : `${this.key}:${this.value}`;
     }
   }
 }

--- a/packages/frontend/src/shared/url-utils.ts
+++ b/packages/frontend/src/shared/url-utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import urljoin from 'url-join';
+import { default as urljoin } from 'url-join';
 
 export function isAbsoluteUrl(url: string) {
   return /^[a-z][\d+.a-z-]*:|\/\//.test(url);

--- a/packages/frontend/src/shared/url-utils.ts
+++ b/packages/frontend/src/shared/url-utils.ts
@@ -25,7 +25,7 @@ export function isRelativeUrl(url: string) {
 }
 
 export function isHashUrl(url: string) {
-  return /^#/.test(url);
+  return url.startsWith('#');
 }
 
 export type MaybeUndefined<T> = undefined extends T ? undefined : never;

--- a/packages/frontend/src/shared/url-utils.ts
+++ b/packages/frontend/src/shared/url-utils.ts
@@ -17,7 +17,7 @@
 import urljoin from 'url-join';
 
 export function isAbsoluteUrl(url: string) {
-  return /(?:^[a-z][a-z0-9+.-]*:|\/\/)/.test(url);
+  return /^[a-z][\d+.a-z-]*:|\/\//.test(url);
 }
 
 export function isRelativeUrl(url: string) {

--- a/packages/frontend/src/shared/useActivities.ts
+++ b/packages/frontend/src/shared/useActivities.ts
@@ -15,7 +15,6 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-
 import type { CombinedError } from 'urql';
 import { gql, useMutation } from 'urql';
 

--- a/packages/frontend/src/shared/useActivities.ts
+++ b/packages/frontend/src/shared/useActivities.ts
@@ -15,6 +15,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+
 import { CombinedError, gql, useMutation } from 'urql';
 
 import { ActivityConnection, ActivityEdge, AutocompleteResults, Sort } from '../models/generated/graphql';

--- a/packages/frontend/src/shared/useActivities.ts
+++ b/packages/frontend/src/shared/useActivities.ts
@@ -16,9 +16,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { CombinedError, gql, useMutation } from 'urql';
+import type { CombinedError } from 'urql';
+import { gql, useMutation } from 'urql';
 
-import { ActivityConnection, ActivityEdge, AutocompleteResults, Sort } from '../models/generated/graphql';
+import type { ActivityConnection, ActivityEdge, AutocompleteResults, Sort } from '../models/generated/graphql';
 import { urqlClient } from '../urql';
 
 const ACTIVITIES_QUERY = gql`

--- a/packages/frontend/src/shared/useInsight.ts
+++ b/packages/frontend/src/shared/useInsight.ts
@@ -19,7 +19,7 @@ import { useSelector } from 'react-redux';
 
 import { gql, useMutation, useQuery } from 'urql';
 
-import { RootState } from '../store/store';
+import type { RootState } from '../store/store';
 
 const INSIGHT_FRAGMENT = gql`
   fragment InsightFields on Insight {

--- a/packages/frontend/src/shared/useInsight.ts
+++ b/packages/frontend/src/shared/useInsight.ts
@@ -16,7 +16,6 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-
 import { gql, useMutation, useQuery } from 'urql';
 
 import type { RootState } from '../store/store';

--- a/packages/frontend/src/shared/useInsight.ts
+++ b/packages/frontend/src/shared/useInsight.ts
@@ -16,6 +16,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
+
 import { gql, useMutation, useQuery } from 'urql';
 
 import { RootState } from '../store/store';

--- a/packages/frontend/src/shared/useLikedBy.ts
+++ b/packages/frontend/src/shared/useLikedBy.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { gql, TypedDocumentNode } from 'urql';
+import type { TypedDocumentNode } from 'urql';
+import { gql } from 'urql';
 
-import { User } from '../models/generated/graphql';
+import type { User } from '../models/generated/graphql';
 import { urqlClient } from '../urql';
 
 type LikedByType = 'insight' | 'comment' | 'activity' | 'news';

--- a/packages/frontend/src/shared/useNews.ts
+++ b/packages/frontend/src/shared/useNews.ts
@@ -18,7 +18,7 @@ import { useCallback } from 'react';
 
 import { gql, useMutation, useQuery } from 'urql';
 
-import { DeleteNewsMutation, DeleteNewsMutationVariables, NewsQuery } from '../models/generated/graphql';
+import type { DeleteNewsMutation, DeleteNewsMutationVariables, NewsQuery } from '../models/generated/graphql';
 
 const NEWS_FRAGMENT = gql`
   fragment NewsFields on News {

--- a/packages/frontend/src/shared/useNews.ts
+++ b/packages/frontend/src/shared/useNews.ts
@@ -15,6 +15,7 @@
  */
 
 import { useCallback } from 'react';
+
 import { gql, useMutation, useQuery } from 'urql';
 
 import { DeleteNewsMutation, DeleteNewsMutationVariables, NewsQuery } from '../models/generated/graphql';

--- a/packages/frontend/src/shared/useNews.ts
+++ b/packages/frontend/src/shared/useNews.ts
@@ -15,7 +15,6 @@
  */
 
 import { useCallback } from 'react';
-
 import { gql, useMutation, useQuery } from 'urql';
 
 import type { DeleteNewsMutation, DeleteNewsMutationVariables, NewsQuery } from '../models/generated/graphql';

--- a/packages/frontend/src/shared/useSearch.ts
+++ b/packages/frontend/src/shared/useSearch.ts
@@ -16,9 +16,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { CombinedError, gql } from 'urql';
+import type { CombinedError } from 'urql';
+import { gql } from 'urql';
 
-import { AutocompleteResults, SearchResult, Sort } from '../models/generated/graphql';
+import type { AutocompleteResults, SearchResult, Sort } from '../models/generated/graphql';
 import { urqlClient } from '../urql';
 
 const INSIGHTS_QUERY = gql`

--- a/packages/frontend/src/shared/useSearch.ts
+++ b/packages/frontend/src/shared/useSearch.ts
@@ -15,7 +15,6 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-
 import type { CombinedError } from 'urql';
 import { gql } from 'urql';
 

--- a/packages/frontend/src/shared/useSearch.ts
+++ b/packages/frontend/src/shared/useSearch.ts
@@ -15,6 +15,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+
 import { CombinedError, gql } from 'urql';
 
 import { AutocompleteResults, SearchResult, Sort } from '../models/generated/graphql';

--- a/packages/frontend/src/shared/useUser.ts
+++ b/packages/frontend/src/shared/useUser.ts
@@ -15,6 +15,7 @@
  */
 
 import { useCallback } from 'react';
+
 import { gql, useQuery } from 'urql';
 
 type UserQuery = 'basic' | 'profile';

--- a/packages/frontend/src/shared/useUser.ts
+++ b/packages/frontend/src/shared/useUser.ts
@@ -15,7 +15,6 @@
  */
 
 import { useCallback } from 'react';
-
 import { gql, useQuery } from 'urql';
 
 type UserQuery = 'basic' | 'profile';

--- a/packages/frontend/src/store/activity.slice.ts
+++ b/packages/frontend/src/store/activity.slice.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 
-import { Paging, Sort } from '../models/generated/graphql';
+import type { Paging, Sort } from '../models/generated/graphql';
 
 export interface ActivityOptions {
   showScores?: boolean;

--- a/packages/frontend/src/store/app.slice.ts
+++ b/packages/frontend/src/store/app.slice.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { DateTime } from 'luxon';
 
-import { AppSettings } from '../models/generated/graphql';
+import type { AppSettings } from '../models/generated/graphql';
 import { urqlClient } from '../urql';
 
 import { login } from './user.slice';

--- a/packages/frontend/src/store/app.slice.ts
+++ b/packages/frontend/src/store/app.slice.ts
@@ -75,11 +75,7 @@ export const initSettings = createAsyncThunk<AppSettings, void, { rejectValue: s
           }`
         )
         .toPromise();
-      if (response.error) {
-        return thunkApi.rejectWithValue(response.error.message);
-      } else {
-        return response.data.appSettings;
-      }
+      return response.error ? thunkApi.rejectWithValue(response.error.message) : response.data.appSettings;
     } catch (error: any) {
       return thunkApi.rejectWithValue(error);
     }

--- a/packages/frontend/src/store/search.slice.ts
+++ b/packages/frontend/src/store/search.slice.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 
-import { Insight, Paging, Sort } from '../models/generated/graphql';
+import type { Insight, Paging, Sort } from '../models/generated/graphql';
 
 export interface SearchOptions {
   layout?: 'default' | 'compact' | 'square';

--- a/packages/frontend/src/store/user.slice.ts
+++ b/packages/frontend/src/store/user.slice.ts
@@ -15,6 +15,7 @@
  */
 
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+
 import { gql } from 'urql';
 
 import { LOCAL_STORAGE_PREFIX } from '../components/auth/github-auth-provider/github-auth-provider';

--- a/packages/frontend/src/store/user.slice.ts
+++ b/packages/frontend/src/store/user.slice.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 import { gql } from 'urql';
 
 import { LOCAL_STORAGE_PREFIX } from '../components/auth/github-auth-provider/github-auth-provider';
-import { User, UserHealthCheck } from '../models/generated/graphql';
+import type { User, UserHealthCheck } from '../models/generated/graphql';
 import { urqlClient, enableAuthorization, disableAuthorization } from '../urql';
 
 export enum LoginState {

--- a/packages/frontend/src/store/user.slice.ts
+++ b/packages/frontend/src/store/user.slice.ts
@@ -72,11 +72,7 @@ export const login = createAsyncThunk<User, string, { rejectValue: string }>(
           `
         )
         .toPromise();
-      if (response.error) {
-        return thunkApi.rejectWithValue(response.error.message);
-      } else {
-        return response.data.login;
-      }
+      return response.error ? thunkApi.rejectWithValue(response.error.message) : response.data.login;
     } catch (error: any) {
       return thunkApi.rejectWithValue(error);
     }
@@ -105,11 +101,7 @@ export const executeHealthCheck = createAsyncThunk<UserHealthCheck, void, { reje
           { requestPolicy: 'network-only' }
         )
         .toPromise();
-      if (response.error) {
-        return thunkApi.rejectWithValue(response.error.message);
-      } else {
-        return response.data.currentUser.healthCheck;
-      }
+      return response.error ? thunkApi.rejectWithValue(response.error.message) : response.data.currentUser.healthCheck;
     } catch (error: any) {
       return thunkApi.rejectWithValue(error);
     }

--- a/packages/frontend/src/store/user.slice.ts
+++ b/packages/frontend/src/store/user.slice.ts
@@ -16,7 +16,6 @@
 
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-
 import { gql } from 'urql';
 
 import { LOCAL_STORAGE_PREFIX } from '../components/auth/github-auth-provider/github-auth-provider';

--- a/packages/frontend/src/urql.ts
+++ b/packages/frontend/src/urql.ts
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-import { cacheExchange, KeyGenerator } from '@urql/exchange-graphcache';
+import type { KeyGenerator } from '@urql/exchange-graphcache';
+import { cacheExchange } from '@urql/exchange-graphcache';
 import type { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast/schema';
 import { multipartFetchExchange } from '@urql/exchange-multipart-fetch';
 import { retryExchange } from '@urql/exchange-retry';
-import { Source, pipe, tap } from 'wonka';
+import type { Source } from 'wonka';
+import { pipe, tap } from 'wonka';
 
-import { createClient, dedupExchange, OperationResult, Operation } from 'urql';
+import type { OperationResult, Operation } from 'urql';
+import { createClient, dedupExchange } from 'urql';
 
 import schema from './introspection.json';
-import { Draft } from './models/generated/graphql';
+import type { Draft } from './models/generated/graphql';
 import { userSlice } from './store/user.slice';
 
 let store: { dispatch: any } | null = null;

--- a/packages/frontend/src/urql.ts
+++ b/packages/frontend/src/urql.ts
@@ -19,11 +19,10 @@ import { cacheExchange } from '@urql/exchange-graphcache';
 import type { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast/schema';
 import { multipartFetchExchange } from '@urql/exchange-multipart-fetch';
 import { retryExchange } from '@urql/exchange-retry';
-import type { Source } from 'wonka';
-import { pipe, tap } from 'wonka';
-
 import type { OperationResult, Operation } from 'urql';
 import { createClient, dedupExchange } from 'urql';
+import type { Source } from 'wonka';
+import { pipe, tap } from 'wonka';
 
 import schema from './introspection.json';
 import type { Draft } from './models/generated/graphql';

--- a/packages/frontend/src/urql.ts
+++ b/packages/frontend/src/urql.ts
@@ -18,8 +18,9 @@ import { cacheExchange, KeyGenerator } from '@urql/exchange-graphcache';
 import type { IntrospectionData } from '@urql/exchange-graphcache/dist/types/ast/schema';
 import { multipartFetchExchange } from '@urql/exchange-multipart-fetch';
 import { retryExchange } from '@urql/exchange-retry';
-import { createClient, dedupExchange, OperationResult, Operation } from 'urql';
 import { Source, pipe, tap } from 'wonka';
+
+import { createClient, dedupExchange, OperationResult, Operation } from 'urql';
 
 import schema from './introspection.json';
 import { Draft } from './models/generated/graphql';


### PR DESCRIPTION
This PR contains a number of commits, each of which updates a particular lint rule.  The vast majority of changes are auto-fixed, but there are a few manual changes where necessary.

Context: After removing Create React App, the frontend package now inherits from the root `.eslintrc.yml` file.  A number of rules were disabled in the PR to migrate to Vite, to avoid fixing lint issues in that PR.  Now, in this PR, I'm re-enabling many of the lint rules that we are already using in the other packages, and fixing the issues.

There remain a few rules that don't work in the frontend/React (or require much larger effort), so they are still commented out.  However, the overall goal is to align the lint rules of all packages as much as possible.