### PR TITLE
fix: Fix missing Markdown styles

### DIFF
--- a/packages/frontend/src/components/markdown-container/chakra-ui-renderer.tsx
+++ b/packages/frontend/src/components/markdown-container/chakra-ui-renderer.tsx
@@ -80,6 +80,14 @@ const heading = ({ node, level, children, ...props }) => {
       borderBottomColor="snowstorm.100"
       display="flex"
       alignItems="center"
+      sx={{
+        // Display self-link on hover
+        '&:hover': {
+          '.heading-auto-link': {
+            display: 'block'
+          }
+        }
+      }}
       {...node.properties}
       {...props}
     >

--- a/packages/frontend/src/components/markdown-container/markdown-container.css
+++ b/packages/frontend/src/components/markdown-container/markdown-container.css
@@ -64,8 +64,3 @@
   font-family: monospace;
   font-size: 1rem;
 }
-
-/* Display heading self-link on hover */
-.iex-markdown-container .heading:hover .heading-auto-link {
-  display: block;
-}

--- a/packages/frontend/src/components/markdown-container/markdown-container.tsx
+++ b/packages/frontend/src/components/markdown-container/markdown-container.tsx
@@ -114,7 +114,7 @@ export const MarkdownContainer = memo(
     );
 
     return (
-      <Box {...boxProps}>
+      <Box {...boxProps} className="iex-markdown-container">
         <ErrorBoundary FallbackComponent={ErrorFallback}>
           <ReactMarkdown
             children={contents}


### PR DESCRIPTION
Markdown styles were lost due to a missing class attribute.

Also refactored one style out of CSS and into JSX. 