### PR TITLE
feat(convertbot): Convert pptx files into individual slide PNGs

### DIFF
--- a/packages/convertbot/README.md
+++ b/packages/convertbot/README.md
@@ -25,6 +25,18 @@ The latest version includes both [Unoconv](https://github.com/unoconv/unoconv) (
 
 </details>
 
+## Supported Conversions
+
+The following conversions are supported:
+
+| From     | To       |
+| -------- | -------- |
+| .docx    | .pdf     |
+| .xlsx    | .pdf     |
+| .pptx    | .pdf <br> .png* |
+| .ipynb   | .html <br> .md <br> .pdf |
+
+\* Powerpoint is converted to PDF, and individual slides are rendered as PNGs. This happens automatically as part of the PDF conversion.
 ## Installation
 
 ```

--- a/packages/convertbot/src/lib/convertbot.ts
+++ b/packages/convertbot/src/lib/convertbot.ts
@@ -26,7 +26,7 @@ import * as tmp from 'tmp-promise';
 export type ConversionMapping = {
   from: string;
   to: string;
-  apply: (source: string) => Promise<string>;
+  apply: (source: string) => Promise<string[]>;
 };
 
 export class Convertbot {
@@ -73,13 +73,26 @@ export class Convertbot {
             // Iterate through targets (one at a time)
             for (let i = 0; i < request.targets.length; i++) {
               const target = request.targets[i];
+              const targetBase = target.uri.slice(0, Math.max(0, target.uri.lastIndexOf('/')));
 
-              logger.debug(`[CONVERTBOT] Starting conversion for ${request.source.uri} to ${target.mimeType}`);
-              const localTargetPath = await this.convert(request.source, target, localSourcePath);
-              logger.debug('[CONVERTBOT] Converted file: ' + localTargetPath);
+              logger.info(`[CONVERTBOT] Starting conversion for ${request.source.uri} to ${target.mimeType}`);
+              const localTargetPaths = await this.convert(request.source, target, localSourcePath);
+              logger.debug('[CONVERTBOT] Converted files: ' + localTargetPaths.join(', '));
 
-              await this.uploadFile(target.uri, localTargetPath);
-              logger.debug('[CONVERTBOT] Uploaded file to: ' + target.uri);
+              for (const [j, localTargetPath] of localTargetPaths.entries()) {
+                logger.debug(`[CONVERTBOT] Uploading file from: ${localTargetPath}`);
+
+                // This is basically a hack to support generating multiple files from a single source
+                // For things like PPTX slide images, IEX doesn't know how many files will be generated, so
+                // it cannot provide a target URI for each file.
+                //
+                // The first localTargetPath will be uploaded to the original target URI, and the rest will be
+                // uploaded to the localTargetPath basename, in the target URI directory.
+                const targetUri = j === 0 ? target.uri : `${targetBase}/${path.basename(localTargetPath)}`;
+
+                await this.uploadFile(targetUri, localTargetPath);
+                logger.info(`[CONVERTBOT] Uploaded file to: ${target.uri}`);
+              }
             }
           } catch (error: any) {
             logger.error(`[CONVERTBOT] Error in conversion: ${error}`);
@@ -88,7 +101,7 @@ export class Convertbot {
         { unsafeCleanup: true }
       );
 
-      logger.debug('[CONVERTBOT] Request completed!');
+      logger.info('[CONVERTBOT] Request completed!');
     });
   }
 
@@ -109,7 +122,7 @@ export class Convertbot {
     });
   }
 
-  private async convert(source: ConvertibleFile, target: ConvertibleFile, localSourcePath: string): Promise<string> {
+  private async convert(source: ConvertibleFile, target: ConvertibleFile, localSourcePath: string): Promise<string[]> {
     logger.info(`[CONVERTBOT] Converting from ${source.mimeType} to ${target.mimeType}`);
 
     const mapping = this.conversionMappings.find((m) => {
@@ -123,8 +136,7 @@ export class Convertbot {
       throw new Error('Unable to convert');
     }
 
-    const localTargetPath = await mapping.apply(localSourcePath);
-    return localTargetPath;
+    return await mapping.apply(localSourcePath);
   }
 
   private async uploadFile(uri: string, localPath: string): Promise<void> {


### PR DESCRIPTION
The PPTX->PDF conversion now includes a step to convert the PDF into PNGs (per slide).  These images are uploaded alongside the converted PDF, with a naming convention of `presentation.pptx-%d.png`

<img width="1023" alt="Screen Shot 2022-03-25 at 10 37 35 AM" src="https://user-images.githubusercontent.com/3084806/160141993-3e015c0a-56be-4a06-9903-2c26fff671e6.png">

