### PR TITLE
fix: Optimize Elasticsearch queries for the user profile

### DIFF
--- a/packages/backend/src/lib/elasticsearch.ts
+++ b/packages/backend/src/lib/elasticsearch.ts
@@ -491,7 +491,7 @@ export async function getInsightsByContributor(
   const insights: Insight[] = elasticResponse.body.hits.hits.map((doc: { _id: string; _source: IndexedInsight }) => {
     const insight = { ...doc._source };
 
-    return insight as Insight;
+    return insight as unknown as Insight;
   });
 
   const edges: Edge<Insight>[] = insights.map((insight) => {

--- a/packages/backend/src/services/user.service.ts
+++ b/packages/backend/src/services/user.service.ts
@@ -230,12 +230,16 @@ export class UserService {
     }
   }
 
-  async getAuthoredInsights(user: User, connectionArgs: ConnectionArgs): Promise<InsightConnection> {
-    return getInsightsByContributor(user.email, connectionArgs);
+  async getAuthoredInsights(
+    user: User,
+    connectionArgs: ConnectionArgs,
+    _source?: string[]
+  ): Promise<InsightConnection> {
+    return getInsightsByContributor(user.email, connectionArgs, _source);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async getLikedInsights(user: User, connectionArgs: ConnectionArgs): Promise<InsightConnection> {
+  async getLikedInsights(user: User, connectionArgs: ConnectionArgs, _source?: string[]): Promise<InsightConnection> {
     const likedUserInsights = await UserInsight.query()
       .where('userId', user.userId)
       .where('liked', true)
@@ -243,7 +247,10 @@ export class UserService {
       .whereNull('insight.deletedAt')
       .orderBy('updatedAt', 'desc');
 
-    const likedInsights = (await getInsights(likedUserInsights.map((i) => i.insightId))) as Insight[];
+    const likedInsights = (await getInsights(
+      likedUserInsights.map((i) => i.insightId),
+      _source
+    )) as unknown as Insight[];
     const currentLikedInsights = likedInsights.filter((i) => i !== null);
 
     return {

--- a/packages/frontend/src/pages/profile-page/profile-page.tsx
+++ b/packages/frontend/src/pages/profile-page/profile-page.tsx
@@ -18,6 +18,7 @@ import { Flex, Spinner } from '@chakra-ui/react';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 
+import { Alert } from '../../components/alert/alert';
 import { useUser } from '../../shared/useUser';
 import type { RootState } from '../../store/store';
 import { ProfileNotFoundPage } from '../profile-not-found-page/profile-not-found-page';
@@ -40,7 +41,7 @@ export const ProfilePage = () => {
 
   return (
     <Flex direction="column" justify="stretch" flexGrow={2}>
-      {error && <p>Oh no... {error.message}</p>}
+      {error && <Alert error={error} />}
       {fetching && <Spinner thickness="4px" speed="0.65s" emptyColor="gray.200" color="blue.500" size="xl" />}
       {!fetching && user && <UserProfile user={user} />}
       {!fetching && user === null && <ProfileNotFoundPage />}


### PR DESCRIPTION
Previously, the `authoredInsights` and `likedInsights` resolvers would trigger Elasticsearch queries which retrieved entire Insight documents, including the contents of all Insight files.  This is obviously a huge hit to performance and network traffic, especially since the Profile page doesn't request that information in the GraphQL query.

To address this, the requested GraphQL fields are being passed down to the Elasticsearch query as the `_source` argument.  Elasticsearch now only returns the requested fields, reducing the traffic and latency.