### PR TITLE
fix: Fix Scroll Sync checkbox on News Admin page

### DIFF
--- a/packages/frontend/src/components/markdown-split-editor/markdown-split-editor.tsx
+++ b/packages/frontend/src/components/markdown-split-editor/markdown-split-editor.tsx
@@ -173,6 +173,7 @@ export const MarkdownSplitEditor = ({
       <HStack justify="flex-end" spacing="0.5rem">
         <Checkbox
           isChecked={scrollSync}
+          isRequired={false}
           onChange={() => setScrollSync(!scrollSync)}
           size="sm"
           color="frost.400"


### PR DESCRIPTION
This PR addresses the fix where the Scroll Sync checkbox on the Insight Split Editor was required to be checked in order to save news on the News Admin page.