### PR TITLE
feat: Allow uploading files to subfolders via button or drag-n-drop

### DIFF
--- a/packages/backend/src/lib/git-instance.ts
+++ b/packages/backend/src/lib/git-instance.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
 import path from 'path';
 import { Readable } from 'stream';
 
 import logger from '@iex/shared/logger';
+import fs from 'fs-extra';
 import globby from 'globby';
 import git from 'isomorphic-git';
 import http from 'isomorphic-git/http/node';
@@ -206,6 +206,9 @@ export class GitInstance {
     }
 
     const localFilePath = path.join(this.localPath, filePath);
+
+    // Ensure the directory exists before we try to write the file there
+    await fs.ensureDir(path.dirname(localFilePath));
 
     const writable = fs.createWriteStream(localFilePath);
     const stream = readable.pipe(writable);

--- a/packages/frontend/src/components/file-browser/components/editable-controls/editable-controls.tsx
+++ b/packages/frontend/src/components/file-browser/components/editable-controls/editable-controls.tsx
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2021 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, HStack, IconButton, Tooltip, useEditableControls } from '@chakra-ui/react';
+
+import { isFolder } from '../../../../shared/file-tree';
+import { iconFactoryAs } from '../../../../shared/icon-factory';
+import { DeleteIconButton } from '../../../delete-icon-button/delete-icon-button';
+
+export const EditableControls = ({ actions, isDeleted, isDisabled, item, onOpen, selected }) => {
+  const { isEditing, getEditButtonProps } = useEditableControls();
+
+  return (
+    <HStack ml="0.25rem" spacing="0.25rem" display="none" className="actions">
+      {isDeleted && (
+        <Tooltip label="Undelete" aria-label="Undelete">
+          <Button
+            aria-label="Undelete"
+            variant="ghost"
+            size="sm"
+            leftIcon={iconFactoryAs('undo')}
+            onClick={() => {
+              if (selected && actions.onUndelete) {
+                actions.onUndelete(selected);
+              }
+            }}
+          >
+            Undelete
+          </Button>
+        </Tooltip>
+      )}
+      {!isDeleted && !isEditing && !item.readonly && (
+        <>
+          <Tooltip label="Rename" aria-label="Rename">
+            <IconButton
+              variant="ghost"
+              size="sm"
+              _hover={{ backgroundColor: 'snowstorm.100' }}
+              aria-label="Rename"
+              icon={iconFactoryAs('edit')}
+              {...getEditButtonProps()}
+            />
+          </Tooltip>
+
+          {isFolder(item) && (
+            <>
+              <Tooltip label="Upload File" aria-label="Upload File">
+                <IconButton
+                  variant="ghost"
+                  size="sm"
+                  _hover={{ backgroundColor: 'aurora.400' }}
+                  aria-label="Upload File"
+                  icon={iconFactoryAs('upload')}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (actions.onFilePicker) {
+                      actions.onFilePicker();
+                    }
+                  }}
+                />
+              </Tooltip>
+              <Tooltip label="New File" aria-label="New File">
+                <IconButton
+                  variant="ghost"
+                  size="sm"
+                  _hover={{ backgroundColor: 'aurora.400' }}
+                  aria-label="New File"
+                  icon={iconFactoryAs('newFile')}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (actions.onNewFile) {
+                      actions.onNewFile(item);
+                      onOpen();
+                    }
+                  }}
+                />
+              </Tooltip>
+              <Tooltip label="New Folder" aria-label="New Folder">
+                <IconButton
+                  variant="ghost"
+                  size="sm"
+                  _hover={{ backgroundColor: 'aurora.400' }}
+                  aria-label="New Folder"
+                  icon={iconFactoryAs('newFolder')}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (actions.onNewFolder) {
+                      actions.onNewFolder(item);
+                      onOpen();
+                    }
+                  }}
+                />
+              </Tooltip>
+            </>
+          )}
+          <DeleteIconButton
+            onClick={() => {
+              if (actions.onDelete) {
+                actions.onDelete(item);
+              }
+            }}
+            isDisabled={item.readonly}
+          />
+        </>
+      )}
+    </HStack>
+  );
+};

--- a/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/insight-editor-sidebar.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/insight-editor-sidebar.tsx
@@ -45,7 +45,13 @@ export const InsightEditorSidebar = ({
   ...flexProps
 }: Props & FlexProps) => {
   return (
-    <Flex direction="column" {...flexProps}>
+    <Flex
+      direction="column"
+      flexGrow={1}
+      flexBasis={{ base: 'unset', md: '20rem', xl: '22rem' }}
+      maxW={{ base: 'unset', md: '20rem', xl: '26rem' }}
+      {...flexProps}
+    >
       <SidebarFiles
         draftKey={draftKey}
         isNewInsight={isNewInsight}

--- a/packages/frontend/src/theme.ts
+++ b/packages/frontend/src/theme.ts
@@ -287,7 +287,7 @@ export const IexTheme = extendTheme({
     Tooltip: {
       baseStyle: (props: Record<string, any>) => {
         return {
-          bg: 'polar.300'
+          bg: props.colorMode === 'dark' ? 'snowstorm.50' : 'polar.300'
         };
       }
     }


### PR DESCRIPTION
This change replaces the file upload drop target in the Insight Editor with the ability to upload to the root folder or any subfolder.  There is a new Upload button for each folder; it appears on subfolders when hovering over them.  Alternately, each folder (including the root) is a drop target and files can be dragged and dropped into the browser

![Screen Shot 2022-04-12 at 2 53 09 PM](https://user-images.githubusercontent.com/3084806/163033406-4c321319-7327-40f5-b6bc-64748ccc5126.png)

![Screen Shot 2022-04-12 at 2 54 10 PM](https://user-images.githubusercontent.com/3084806/163033413-370d3031-f4e8-4845-901f-c8992f370e30.png)
.