### PR TITLE
feat: Reorganize Insight Files via drag and drop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4002,6 +4002,21 @@
         "react-dom": "^16.8.0 || 17.x"
       }
     },
+    "node_modules/@react-dnd/asap": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.0.tgz",
+      "integrity": "sha512-czNGSkNPZgxapKz1a8zj/C5me5MpVpN4wlXDQIMF4wDUuFJ37x7beakc4S7C1xKilHA4tgT9zZb4U64BdT/E5g=="
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.0.tgz",
+      "integrity": "sha512-tjPrh294NbH6Gj1YP1of6JYEe3+sm0Wy7YA1ImG6YghlZe3n8F+fBx1yIrA5dVJCuUh6pBp4XO7/lcSq7oLL0A=="
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.0.tgz",
+      "integrity": "sha512-Yykovind6xzqAqd0t5umrdAGPlGLTE80cy80UkEnbt8Zv5zEYTFzJSNPQ81TY8BSpRreubu1oE54iHBv2UVnTQ=="
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.1.tgz",
@@ -8411,6 +8426,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dnd-core": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.0.tgz",
+      "integrity": "sha512-8cGtybb5LBjG2euYgVv3amk49F+9dH3l5TuuGQf0mhFr+KWIPE1qPxB8VpPDov74ZevUAxVDxadL2zN7I0oQ1Q==",
+      "dependencies": {
+        "@react-dnd/asap": "^5.0.0",
+        "@react-dnd/invariant": "^4.0.0",
+        "redux": "^4.1.2"
       }
     },
     "node_modules/doctrine": {
@@ -18518,6 +18543,43 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
+    "node_modules/react-dnd": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.0.tgz",
+      "integrity": "sha512-RCoeWRWhuwSoqdLaJV8N/weARLyXqsf43OC3QiBWPORIIGGovF/EqI8ckf14ca3bl6oZNI/igtxX49+IDmNDeQ==",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.0",
+        "@react-dnd/shallowequal": "^4.0.0",
+        "dnd-core": "^16.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.0.tgz",
+      "integrity": "sha512-be3lKEbbT8FQcoTjFlQ4ZXG/NVrFNJu9W0INc5rm/5EFQpHCkz+xpbB2U8j9uh5Bvk7AsJyQrZznEut0hrNPIA==",
+      "dependencies": {
+        "dnd-core": "^16.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -22869,6 +22931,31 @@
         }
       }
     },
+    "node_modules/use-file-picker": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/use-file-picker/-/use-file-picker-1.4.2.tgz",
+      "integrity": "sha512-RkJlsHko25I2zZOAMhph1ZDfmnDtWwkFZqJzmD71vM5chIECogWt0qmyGIsn+gnCYbwsWdiGHfI6LjpGgWu1TQ==",
+      "dependencies": {
+        "file-selector": "0.2.4"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/use-file-picker/node_modules/file-selector": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.2.4.tgz",
+      "integrity": "sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/use-sidecar": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
@@ -23131,6 +23218,12 @@
         "vega": "^5.21.0",
         "vega-lite": "*"
       }
+    },
+    "node_modules/vega-embed/node_modules/yallist": {
+      "version": "4.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
     },
     "node_modules/vega-encode": {
       "version": "4.9.0",
@@ -24479,6 +24572,8 @@
         "react-confetti": "6.0.1",
         "react-container-dimensions": "1.4.1",
         "react-datepicker": "4.6.0",
+        "react-dnd": "16.0.0",
+        "react-dnd-html5-backend": "16.0.0",
         "react-dom": "17.0.2",
         "react-dropzone": "12.0.5",
         "react-error-boundary": "3.1.4",
@@ -24508,6 +24603,7 @@
         "unist-util-visit": "4.0.0",
         "url-join": "4.0.1",
         "urql": "2.2.0",
+        "use-file-picker": "1.4.2",
         "use-trace-update": "1.3.2",
         "vega": "5.22.1",
         "vega-lite": "5.2.0"
@@ -27292,6 +27388,8 @@
         "react-confetti": "6.0.1",
         "react-container-dimensions": "1.4.1",
         "react-datepicker": "4.6.0",
+        "react-dnd": "16.0.0",
+        "react-dnd-html5-backend": "16.0.0",
         "react-dom": "17.0.2",
         "react-dropzone": "12.0.5",
         "react-error-boundary": "3.1.4",
@@ -27323,6 +27421,7 @@
         "unist-util-visit": "4.0.0",
         "url-join": "4.0.1",
         "urql": "2.2.0",
+        "use-file-picker": "*",
         "use-trace-update": "1.3.2",
         "vega": "5.22.1",
         "vega-lite": "5.2.0",
@@ -28071,6 +28170,21 @@
         "prop-types": "^15.7.2",
         "tslib": "^2.1.0"
       }
+    },
+    "@react-dnd/asap": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.0.tgz",
+      "integrity": "sha512-czNGSkNPZgxapKz1a8zj/C5me5MpVpN4wlXDQIMF4wDUuFJ37x7beakc4S7C1xKilHA4tgT9zZb4U64BdT/E5g=="
+    },
+    "@react-dnd/invariant": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.0.tgz",
+      "integrity": "sha512-tjPrh294NbH6Gj1YP1of6JYEe3+sm0Wy7YA1ImG6YghlZe3n8F+fBx1yIrA5dVJCuUh6pBp4XO7/lcSq7oLL0A=="
+    },
+    "@react-dnd/shallowequal": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.0.tgz",
+      "integrity": "sha512-Yykovind6xzqAqd0t5umrdAGPlGLTE80cy80UkEnbt8Zv5zEYTFzJSNPQ81TY8BSpRreubu1oE54iHBv2UVnTQ=="
     },
     "@reduxjs/toolkit": {
       "version": "1.8.1",
@@ -31628,6 +31742,16 @@
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "requires": {
         "path-type": "^4.0.0"
+      }
+    },
+    "dnd-core": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.0.tgz",
+      "integrity": "sha512-8cGtybb5LBjG2euYgVv3amk49F+9dH3l5TuuGQf0mhFr+KWIPE1qPxB8VpPDov74ZevUAxVDxadL2zN7I0oQ1Q==",
+      "requires": {
+        "@react-dnd/asap": "^5.0.0",
+        "@react-dnd/invariant": "^4.0.0",
+        "redux": "^4.1.2"
       }
     },
     "doctrine": {
@@ -39070,6 +39194,26 @@
         }
       }
     },
+    "react-dnd": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.0.tgz",
+      "integrity": "sha512-RCoeWRWhuwSoqdLaJV8N/weARLyXqsf43OC3QiBWPORIIGGovF/EqI8ckf14ca3bl6oZNI/igtxX49+IDmNDeQ==",
+      "requires": {
+        "@react-dnd/invariant": "^4.0.0",
+        "@react-dnd/shallowequal": "^4.0.0",
+        "dnd-core": "^16.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      }
+    },
+    "react-dnd-html5-backend": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.0.tgz",
+      "integrity": "sha512-be3lKEbbT8FQcoTjFlQ4ZXG/NVrFNJu9W0INc5rm/5EFQpHCkz+xpbB2U8j9uh5Bvk7AsJyQrZznEut0hrNPIA==",
+      "requires": {
+        "dnd-core": "^16.0.0"
+      }
+    },
     "react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -42351,6 +42495,24 @@
       "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==",
       "requires": {}
     },
+    "use-file-picker": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/use-file-picker/-/use-file-picker-1.4.2.tgz",
+      "integrity": "sha512-RkJlsHko25I2zZOAMhph1ZDfmnDtWwkFZqJzmD71vM5chIECogWt0qmyGIsn+gnCYbwsWdiGHfI6LjpGgWu1TQ==",
+      "requires": {
+        "file-selector": "0.2.4"
+      },
+      "dependencies": {
+        "file-selector": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.2.4.tgz",
+          "integrity": "sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==",
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        }
+      }
+    },
     "use-sidecar": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
@@ -42568,6 +42730,13 @@
         "vega-schema-url-parser": "^2.2.0",
         "vega-themes": "^2.10.0",
         "vega-tooltip": "^0.27.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "bundled": true,
+          "extraneous": true
+        }
       }
     },
     "vega-encode": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -35,6 +35,8 @@
     "react-confetti": "6.0.1",
     "react-container-dimensions": "1.4.1",
     "react-datepicker": "4.6.0",
+    "react-dnd": "16.0.0",
+    "react-dnd-html5-backend": "16.0.0",
     "react-dom": "17.0.2",
     "react-dropzone": "12.0.5",
     "react-error-boundary": "3.1.4",
@@ -64,6 +66,7 @@
     "unist-util-visit": "4.0.0",
     "url-join": "4.0.1",
     "urql": "2.2.0",
+    "use-file-picker": "1.4.2",
     "use-trace-update": "1.3.2",
     "vega": "5.22.1",
     "vega-lite": "5.2.0"

--- a/packages/frontend/src/components/file-browser/components/editable-controls/editable-controls.tsx
+++ b/packages/frontend/src/components/file-browser/components/editable-controls/editable-controls.tsx
@@ -32,9 +32,10 @@ export const EditableControls = ({ actions, isDeleted, isDisabled, item, onOpen,
             variant="ghost"
             size="sm"
             leftIcon={iconFactoryAs('undo')}
-            onClick={() => {
-              if (selected && actions.onUndelete) {
-                actions.onUndelete(selected);
+            onClick={(event) => {
+              event.stopPropagation();
+              if (actions.onUndelete) {
+                actions.onUndelete(item);
               }
             }}
           >

--- a/packages/frontend/src/components/file-browser/file-browser.tsx
+++ b/packages/frontend/src/components/file-browser/file-browser.tsx
@@ -40,7 +40,6 @@ import { fileIconFactoryAs } from '../../shared/file-icon-factory';
 import type { InsightFileTree } from '../../shared/file-tree';
 import { isFolder } from '../../shared/file-tree';
 import { iconFactoryAs } from '../../shared/icon-factory';
-import { DeleteIconButton } from '../delete-icon-button/delete-icon-button';
 
 import { EditableControls } from './components/editable-controls/editable-controls';
 

--- a/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/insight-editor-sidebar.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/insight-editor-sidebar.tsx
@@ -15,6 +15,7 @@
  */
 
 import type { FlexProps } from '@chakra-ui/react';
+import { useDisclosure } from '@chakra-ui/react';
 import { Flex } from '@chakra-ui/react';
 import type { UseFormReturn } from 'react-hook-form';
 
@@ -44,18 +45,24 @@ export const InsightEditorSidebar = ({
   fileTree,
   ...flexProps
 }: Props & FlexProps) => {
+  const { isOpen: isFilesOpen, onToggle: onFilesToggle } = useDisclosure({ defaultIsOpen: true });
+
   return (
     <Flex
       direction="column"
-      flexGrow={1}
-      flexBasis={{ base: 'unset', md: '20rem', xl: '22rem' }}
+      {...(isFilesOpen && {
+        flexGrow: 1,
+        flexBasis: { base: 'unset', md: '20rem', xl: '22rem' }
+      })}
       maxW={{ base: 'unset', md: '20rem', xl: '26rem' }}
       {...flexProps}
     >
       <SidebarFiles
         draftKey={draftKey}
+        isFilesOpen={isFilesOpen}
         isNewInsight={isNewInsight}
         tree={fileTree}
+        onFilesToggle={onFilesToggle}
         onSelectFile={onSelectFile}
         onTreeChanged={onFileTreeChanged}
       />

--- a/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/insight-editor-sidebar.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/insight-editor-sidebar.tsx
@@ -17,6 +17,8 @@
 import type { FlexProps } from '@chakra-ui/react';
 import { useDisclosure } from '@chakra-ui/react';
 import { Flex } from '@chakra-ui/react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
 import type { UseFormReturn } from 'react-hook-form';
 
 import type { InsightFile } from '../../../../models/file-tree';
@@ -57,15 +59,17 @@ export const InsightEditorSidebar = ({
       maxW={{ base: 'unset', md: '20rem', xl: '26rem' }}
       {...flexProps}
     >
-      <SidebarFiles
-        draftKey={draftKey}
-        isFilesOpen={isFilesOpen}
-        isNewInsight={isNewInsight}
-        tree={fileTree}
-        onFilesToggle={onFilesToggle}
-        onSelectFile={onSelectFile}
-        onTreeChanged={onFileTreeChanged}
-      />
+      <DndProvider backend={HTML5Backend}>
+        <SidebarFiles
+          draftKey={draftKey}
+          isFilesOpen={isFilesOpen}
+          isNewInsight={isNewInsight}
+          tree={fileTree}
+          onFilesToggle={onFilesToggle}
+          onSelectFile={onSelectFile}
+          onTreeChanged={onFileTreeChanged}
+        />
+      </DndProvider>
     </Flex>
   );
 };

--- a/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/sidebar-files.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-editor-sidebar/sidebar-files.tsx
@@ -19,31 +19,19 @@ import type { FlexProps } from '@chakra-ui/react';
 import { useColorModeValue } from '@chakra-ui/react';
 import { Progress } from '@chakra-ui/react';
 import { Divider } from '@chakra-ui/react';
-import {
-  Box,
-  Collapse,
-  Flex,
-  IconButton,
-  Spinner,
-  Text,
-  useDisclosure,
-  useToast,
-  VStack,
-  HStack
-} from '@chakra-ui/react';
+import { Box, Collapse, Flex, IconButton, Text, useToast, HStack } from '@chakra-ui/react';
 import { nanoid } from 'nanoid';
 import { useCallback, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { gql } from 'urql';
 
 import { FileBrowser } from '../../../../components/file-browser/file-browser';
-import { FileUploadArea } from '../../../../components/file-upload-area/file-upload-area';
 import { SidebarHeading } from '../../../../components/sidebar-heading/sidebar-heading';
 import type { FileOrFolder, InsightFile, InsightFolder } from '../../../../models/file-tree';
 import { InsightFileAction } from '../../../../models/file-tree';
 import type { UploadSingleFileMutation } from '../../../../models/generated/graphql';
 import type { InsightFileTree } from '../../../../shared/file-tree';
-import { iconFactory, iconFactoryAs } from '../../../../shared/icon-factory';
+import { iconFactoryAs } from '../../../../shared/icon-factory';
 import { urqlClient } from '../../../../urql';
 
 const UPLOAD_SINGLE_FILE_MUTATION = gql`
@@ -60,7 +48,9 @@ const UPLOAD_SINGLE_FILE_MUTATION = gql`
 
 interface Props {
   draftKey: string;
+  isFilesOpen: boolean;
   isNewInsight: boolean;
+  onFilesToggle: () => void;
   onSelectFile: (f: InsightFile | undefined) => void;
   onTreeChanged: (tree: InsightFileTree) => void;
   tree: InsightFileTree;
@@ -68,7 +58,9 @@ interface Props {
 
 export const SidebarFiles = ({
   draftKey,
+  isFilesOpen,
   isNewInsight,
+  onFilesToggle,
   onSelectFile,
   onTreeChanged,
   tree,
@@ -179,8 +171,6 @@ export const SidebarFiles = ({
   };
 
   const isMobile = useBreakpointValue({ base: true, md: false });
-
-  const { isOpen: isFilesOpen, onToggle: onFilesToggle } = useDisclosure({ defaultIsOpen: true });
 
   const iconOption = useBreakpointValue({
     base: isFilesOpen ? iconFactoryAs('chevronUp') : iconFactoryAs('chevronDown'),

--- a/packages/frontend/src/shared/use-file-picker.ts
+++ b/packages/frontend/src/shared/use-file-picker.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2022 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useFilePicker as ufp } from 'use-file-picker';
+
+export const useFilePicker = ({ onFilesPicked }): [() => void, Record<string, any>] => {
+  const previousFile = useRef<any | undefined>(undefined);
+  const [openFileSelector, { loading, errors, plainFiles, clear }] = ufp({
+    multiple: true,
+    maxFileSize: 100, // in MB
+    limitFilesConfig: { max: 10 },
+    readFilesContent: true
+  });
+
+  useEffect(() => {
+    if (previousFile.current != plainFiles && plainFiles.length > 0) {
+      previousFile.current = plainFiles;
+      onFilesPicked(plainFiles);
+      clear();
+    }
+  }, [clear, onFilesPicked, plainFiles]);
+
+  return [
+    openFileSelector,
+    {
+      loading,
+      errors
+    }
+  ];
+};


### PR DESCRIPTION
This commit updates the Insight Editor sidebar to support the following features:
- Moving files between various folders via drag and drop
- Drag and drop file(s) from the computer directly into a folder
- Upload files into a folder via an Upload button

The latter two features are not new, but have been rewritten using `react-dnd`.  This avoids conflicts from having both `react-dropzone` and `react-dnd` wired to the same drop targets.

These features work for the root folder as well as any subfolders or nested subfolders.

This PR also includes a few small UX changes uncovered while developing this feature.

<img width="347" alt="Screen Shot 2022-04-14 at 6 19 22 PM" src="https://user-images.githubusercontent.com/3084806/163486292-645ef025-65ff-4fcf-89d9-9a74790094b7.png">

![3 10 1 - Drag and Drop](https://user-images.githubusercontent.com/3084806/163485647-9623c072-26c6-4bb2-9afe-f72f67c69820.gif)

