### PR TITLE
refactor: Migrate to pino logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2330,16 +2330,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@dabh/diagnostics": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
-      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
-      "dependencies": {
-        "colorspace": "1.1.x",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
-      }
-    },
     "node_modules/@elastic/elasticsearch": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz",
@@ -4852,15 +4842,6 @@
       "integrity": "sha512-DN/CCT1HQG6HquBNJdLkvV+4v5l/oEuwOHUPLxI+Eub0NED+lk0YUfba04WGH90EINiUrNgClkNnwGmbICeWMQ==",
       "dev": true
     },
-    "node_modules/@types/morgan": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.3.tgz",
-      "integrity": "sha512-BiLcfVqGBZCyNCnCH3F4o2GmDLrpy0HeBVnNlyZG4fo88ZiE9SoiBe3C+2ezuwbjlEyT+PDZ17//TAlRxAn75Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
@@ -5098,7 +5079,8 @@
     "node_modules/@types/turndown": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.1.tgz",
-      "integrity": "sha512-N8Ad4e3oJxh9n9BiZx9cbe/0M3kqDpOTm2wzj13wdDUxDPjfjloWIJaquZzWE1cYTAHpjOH3rcTnXQdpEfS/SQ=="
+      "integrity": "sha512-N8Ad4e3oJxh9n9BiZx9cbe/0M3kqDpOTm2wzj13wdDUxDPjfjloWIJaquZzWE1cYTAHpjOH3rcTnXQdpEfS/SQ==",
+      "dev": true
     },
     "node_modules/@types/unist": {
       "version": "2.0.6",
@@ -5791,6 +5773,108 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
+    "node_modules/args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "dependencies": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/args/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/camelcase": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/args/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/args/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "node_modules/args/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/args/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/args/node_modules/mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.3.tgz",
@@ -6006,6 +6090,14 @@
       },
       "engines": {
         "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/attr-accept": {
@@ -6357,17 +6449,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/batch-processor": {
       "version": "1.0.0",
@@ -7316,15 +7397,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "dependencies": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7341,49 +7413,10 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/color-string": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/color/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
     "node_modules/colorette": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/colorspace": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-      "dependencies": {
-        "color": "^3.1.3",
-        "text-hex": "1.0.x"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -8113,6 +8146,14 @@
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
@@ -8611,6 +8652,17 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
+    "node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -8672,11 +8724,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/enabled": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
-    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -8689,7 +8736,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -10572,16 +10618,36 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-redact": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.1.tgz",
+      "integrity": "sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fast-shallow-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "node_modules/fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "dependencies": {
+        "punycode": "^1.3.2"
+      }
+    },
+    "node_modules/fast-url-parser/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "node_modules/fastest-stable-stringify": {
       "version": "2.0.2",
@@ -10637,11 +10703,6 @@
       "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
       "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
       "dev": true
-    },
-    "node_modules/fecha": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
-      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -10965,11 +11026,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
-    },
-    "node_modules/fn.name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/focus-lock": {
       "version": "0.9.2",
@@ -13924,6 +13980,14 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jquery-extend": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/jquery-extend/-/jquery-extend-2.0.3.tgz",
@@ -14346,11 +14410,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/kuler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.21",
@@ -15097,18 +15156,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/logform": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.3.2.tgz",
-      "integrity": "sha512-V6JiPThZzTsbVRspNO6TmHkR99oqYTs8fivMBYQkjZj6rxW92KxtDCPE6IkAk1DNBnYKNkjm4jYBm6JDUcyhOA==",
-      "dependencies": {
-        "colors": "1.4.0",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "safe-stable-stringify": "^1.1.0",
-        "triple-beam": "^1.3.0"
       }
     },
     "node_modules/loglevel": {
@@ -16516,42 +16563,6 @@
       "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
       "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
     },
-    "node_modules/morgan": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
-      "dependencies": {
-        "basic-auth": "~2.0.1",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/morgan/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/morgan/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/morgan/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -17467,6 +17478,11 @@
       "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
       "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -17492,14 +17508,6 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/one-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "dependencies": {
-        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -17994,14 +18002,6 @@
         "split2": "^4.1.0"
       }
     },
-    "node_modules/pgpass/node_modules/split2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
-      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -18036,6 +18036,93 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pino": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.10.0.tgz",
+      "integrity": "sha512-T6R92jy/APDElEuOk0gqa4nds3ZgqFbHde2X0g8XorlyPlVGlr9T5KQphtp72a3ByKOdZMg/gM/0IprpGQfTWg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.0.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.15.1"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "dependencies": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-http": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-6.6.0.tgz",
+      "integrity": "sha512-PlItaK2MLpoIMLEcClhfb1VQk/o6fKppINl5s6sPE/4rvufkdO3kCSs/92EwrBsB1yssRCQqDV+w1xpYuPVnjg==",
+      "dependencies": {
+        "fast-url-parser": "^1.1.3",
+        "get-caller-file": "^2.0.5",
+        "pino": "^7.5.0",
+        "pino-std-serializers": "^5.0.0"
+      }
+    },
+    "node_modules/pino-http/node_modules/pino-std-serializers": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-5.2.0.tgz",
+      "integrity": "sha512-tnEZoW/OpiQoL0laBC0CWJ0HPeISW2lrjUK0twYjqdGnggM8ZYk1XG8ucvjMCV0R7kMxO7Z63a27UhpkQw7Rrg=="
+    },
+    "node_modules/pino-pretty": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-7.6.1.tgz",
+      "integrity": "sha512-H7N6ZYkiyrfwBGW9CSjx0uyO9Q2Lyt73881+OTYk8v3TiTdgN92QHrWlEq/LeWw5XtDP64jeSk3mnc6T+xX9/w==",
+      "dependencies": {
+        "args": "^5.0.1",
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-safe-stringify": "^2.0.7",
+        "joycon": "^3.1.1",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "^0.5.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^2.2.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/colorette": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
+    },
+    "node_modules/pino/node_modules/safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/pirates": {
@@ -18208,6 +18295,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+    },
     "node_modules/promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -18304,7 +18396,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -18384,6 +18475,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -19278,6 +19374,14 @@
       "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
       "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg=="
     },
+    "node_modules/real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -19942,6 +20046,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -20118,11 +20227,6 @@
       "dependencies": {
         "regexp-tree": "~0.1.1"
       }
-    },
-    "node_modules/safe-stable-stringify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
-      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -20783,19 +20887,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -21010,6 +21101,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "node_modules/sonic-boom": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.7.0.tgz",
+      "integrity": "sha512-Ynxp0OGQG91wvDjCbFlRMHbSUmDq7dE/EgDeUJ/j+Q9x1FVkFry20cjLykxRSmlm3QS0B4JYAKE8239XKN4SHQ==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -21120,6 +21219,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sponge-case": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
@@ -21152,14 +21259,6 @@
       "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
       "dependencies": {
         "stackframe": "^1.1.1"
-      }
-    },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/stack-utils": {
@@ -21310,6 +21409,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "node_modules/streamsearch": {
       "version": "0.1.2",
@@ -21495,7 +21599,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -21744,16 +21847,19 @@
       "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
       "deprecated": "no longer maintained"
     },
-    "node_modules/text-hex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "node_modules/thread-stream": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
+      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+      "dependencies": {
+        "real-require": "^0.1.0"
+      }
     },
     "node_modules/throat": {
       "version": "6.0.1",
@@ -22072,11 +22178,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/triple-beam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "node_modules/trough": {
       "version": "2.0.2",
@@ -23138,6 +23239,12 @@
         "vega-lite": "*"
       }
     },
+    "node_modules/vega-embed/node_modules/yallist": {
+      "version": "4.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
     "node_modules/vega-encode": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.0.tgz",
@@ -24012,63 +24119,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/winston": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.5.1.tgz",
-      "integrity": "sha512-tbRtVy+vsSSCLcZq/8nXZaOie/S2tPXPFt4be/Q3vI/WtYwm7rrwidxVw2GRa38FIXcJ1kUM6MOZ9Jmnk3F3UA==",
-      "dependencies": {
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.3.2",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.4.2"
-      },
-      "engines": {
-        "node": ">= 6.4.0"
-      }
-    },
-    "node_modules/winston-transport": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.2.tgz",
-      "integrity": "sha512-9jmhltAr5ygt5usgUTQbEiw/7RYXpyUbEAFRCSicIacpUzPkrnQsQZSPGEI12aLK9Jth4zNcYJx3Cvznwrl8pw==",
-      "dependencies": {
-        "logform": "^2.3.2",
-        "readable-stream": "^3.4.0",
-        "triple-beam": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 6.4.0"
-      }
-    },
-    "node_modules/winston/node_modules/async": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
-    },
-    "node_modules/winston/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/winston/node_modules/safe-stable-stringify": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
-      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/wonka": {
       "version": "4.0.15",
       "resolved": "https://registry.npmjs.org/wonka/-/wonka-4.0.15.tgz",
@@ -24317,7 +24367,6 @@
         "@elastic/elasticsearch": "7.13.0",
         "@octokit/graphql": "4.8.0",
         "@octokit/rest": "18.12.0",
-        "@types/turndown": "5.0.1",
         "apollo-server-core": "3.6.7",
         "apollo-server-express": "3.6.7",
         "aws-sdk": "2.1113.0",
@@ -24349,7 +24398,6 @@
         "luxon": "2.3.1",
         "mime": "3.0.0",
         "module-alias": "2.2.2",
-        "morgan": "1.10.0",
         "nanoid": "3.3.3",
         "node-cache": "5.1.2",
         "node-html-parser": "3.3.6",
@@ -24366,8 +24414,7 @@
         "tweetnacl": "1.0.3",
         "tweetnacl-util": "0.15.1",
         "type-graphql": "1.1.1",
-        "typedi": "0.10.0",
-        "winston": "3.5.1"
+        "typedi": "0.10.0"
       },
       "devDependencies": {
         "@types/better-queue": "3.8.3",
@@ -24386,11 +24433,11 @@
         "@types/luxon": "2.3.1",
         "@types/mime": "2.0.3",
         "@types/module-alias": "2.0.1",
-        "@types/morgan": "1.9.3",
         "@types/node": "16.11.26",
         "@types/parsimmon": "1.10.6",
         "@types/supertest": "2.0.12",
         "@types/tmp": "0.2.3",
+        "@types/turndown": "5.0.1",
         "@types/validator": "13.7.2",
         "@typescript-eslint/eslint-plugin": "5.19.0",
         "@typescript-eslint/parser": "5.19.0",
@@ -24422,7 +24469,6 @@
         "helmet": "5.0.2",
         "http-status-codes": "2.2.0",
         "module-alias": "2.2.2",
-        "morgan": "1.10.0",
         "reflect-metadata": "0.1.13",
         "tmp-promise": "3.0.3"
       },
@@ -24432,7 +24478,6 @@
         "@types/express": "4.17.13",
         "@types/jest": "27.4.1",
         "@types/module-alias": "2.0.1",
-        "@types/morgan": "1.9.3",
         "@types/node": "16.11.26",
         "@types/tmp": "0.2.3",
         "@typescript-eslint/eslint-plugin": "5.19.0",
@@ -24622,7 +24667,9 @@
         "fs-extra": "10.0.1",
         "lodash": "4.17.21",
         "parsimmon": "1.18.1",
-        "winston": "3.5.1"
+        "pino": "7.10.0",
+        "pino-http": "6.6.0",
+        "pino-pretty": "7.6.1"
       },
       "devDependencies": {
         "@types/fs-extra": "9.0.13",
@@ -24644,7 +24691,6 @@
         "dotenv-flow": "3.2.0",
         "express": "4.17.3",
         "module-alias": "2.2.2",
-        "morgan": "1.10.0",
         "reflect-metadata": "0.1.13",
         "tmp-promise": "3.0.3"
       },
@@ -24653,7 +24699,6 @@
         "@types/express": "4.17.13",
         "@types/jest": "27.4.1",
         "@types/module-alias": "2.0.1",
-        "@types/morgan": "1.9.3",
         "@types/node": "16.11.26",
         "@types/tmp": "0.2.3",
         "@typescript-eslint/eslint-plugin": "5.19.0",
@@ -26330,16 +26375,6 @@
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz",
       "integrity": "sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ=="
     },
-    "@dabh/diagnostics": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
-      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
-      "requires": {
-        "colorspace": "1.1.x",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
-      }
-    },
     "@elastic/elasticsearch": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz",
@@ -27055,7 +27090,6 @@
         "@types/luxon": "2.3.1",
         "@types/mime": "2.0.3",
         "@types/module-alias": "2.0.1",
-        "@types/morgan": "1.9.3",
         "@types/node": "16.11.26",
         "@types/parsimmon": "1.10.6",
         "@types/supertest": "2.0.12",
@@ -27104,7 +27138,6 @@
         "luxon": "2.3.1",
         "mime": "3.0.0",
         "module-alias": "2.2.2",
-        "morgan": "1.10.0",
         "nanoid": "3.3.3",
         "node-cache": "5.1.2",
         "node-html-parser": "3.3.6",
@@ -27127,8 +27160,7 @@
         "tweetnacl-util": "0.15.1",
         "type-graphql": "1.1.1",
         "typedi": "0.10.0",
-        "typescript": "4.6.3",
-        "winston": "3.5.1"
+        "typescript": "4.6.3"
       }
     },
     "@iex/convertbot": {
@@ -27139,7 +27171,6 @@
         "@types/express": "4.17.13",
         "@types/jest": "27.4.1",
         "@types/module-alias": "2.0.1",
-        "@types/morgan": "1.9.3",
         "@types/node": "16.11.26",
         "@types/tmp": "0.2.3",
         "@typescript-eslint/eslint-plugin": "5.19.0",
@@ -27157,7 +27188,6 @@
         "http-status-codes": "2.2.0",
         "jest": "27.5.1",
         "module-alias": "2.2.2",
-        "morgan": "1.10.0",
         "nodemon": "2.0.15",
         "npm-run-all": "4.1.5",
         "prettier": "2.6.2",
@@ -27324,9 +27354,11 @@
         "jest": "27.5.1",
         "lodash": "4.17.21",
         "parsimmon": "1.18.1",
+        "pino": "7.10.0",
+        "pino-http": "6.6.0",
+        "pino-pretty": "7.6.1",
         "ts-jest": "27.1.4",
-        "typescript": "4.6.3",
-        "winston": "3.5.1"
+        "typescript": "4.6.3"
       }
     },
     "@iex/slackbot": {
@@ -27338,7 +27370,6 @@
         "@types/express": "4.17.13",
         "@types/jest": "27.4.1",
         "@types/module-alias": "2.0.1",
-        "@types/morgan": "1.9.3",
         "@types/node": "16.11.26",
         "@types/tmp": "0.2.3",
         "@typescript-eslint/eslint-plugin": "5.19.0",
@@ -27352,7 +27383,6 @@
         "express": "4.17.3",
         "jest": "27.5.1",
         "module-alias": "2.2.2",
-        "morgan": "1.10.0",
         "nodemon": "2.0.15",
         "npm-run-all": "4.1.5",
         "prettier": "2.6.2",
@@ -28751,15 +28781,6 @@
       "integrity": "sha512-DN/CCT1HQG6HquBNJdLkvV+4v5l/oEuwOHUPLxI+Eub0NED+lk0YUfba04WGH90EINiUrNgClkNnwGmbICeWMQ==",
       "dev": true
     },
-    "@types/morgan": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.3.tgz",
-      "integrity": "sha512-BiLcfVqGBZCyNCnCH3F4o2GmDLrpy0HeBVnNlyZG4fo88ZiE9SoiBe3C+2ezuwbjlEyT+PDZ17//TAlRxAn75Q==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
@@ -28994,7 +29015,8 @@
     "@types/turndown": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.1.tgz",
-      "integrity": "sha512-N8Ad4e3oJxh9n9BiZx9cbe/0M3kqDpOTm2wzj13wdDUxDPjfjloWIJaquZzWE1cYTAHpjOH3rcTnXQdpEfS/SQ=="
+      "integrity": "sha512-N8Ad4e3oJxh9n9BiZx9cbe/0M3kqDpOTm2wzj13wdDUxDPjfjloWIJaquZzWE1cYTAHpjOH3rcTnXQdpEfS/SQ==",
+      "dev": true
     },
     "@types/unist": {
       "version": "2.0.6",
@@ -29489,6 +29511,83 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
+    "args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "requires": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "leven": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+          "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+        },
+        "mri": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+          "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "aria-hidden": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.3.tgz",
@@ -29647,6 +29746,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "attr-accept": {
       "version": "2.2.2",
@@ -29923,14 +30027,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
     },
     "batch-processor": {
       "version": "1.0.0",
@@ -30672,30 +30768,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "requires": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        }
-      }
-    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -30709,33 +30781,10 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "color-string": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
     "colorette": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
-    },
-    "colorspace": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-      "requires": {
-        "color": "^3.1.3",
-        "text-hex": "1.0.x"
-      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -31319,6 +31368,11 @@
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
     },
+    "dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
+    },
     "dayjs": {
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
@@ -31710,6 +31764,17 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
+    "duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -31758,11 +31823,6 @@
       "resolved": "https://registry.npmjs.org/emoticon/-/emoticon-4.0.1.tgz",
       "integrity": "sha512-dqx7eA9YaqyvYtUhJwT4rC1HIp82j5ybS1/vQ42ur+jBe17dJMwZE4+gvL1XadSFfxaPFFGt3Xsw+Y8akThDlw=="
     },
-    "enabled": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
-    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -31772,7 +31832,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -33118,16 +33177,35 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-redact": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.1.tgz",
+      "integrity": "sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A=="
+    },
     "fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fast-shallow-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
     },
     "fastest-stable-stringify": {
       "version": "2.0.2",
@@ -33179,11 +33257,6 @@
       "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
       "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
       "dev": true
-    },
-    "fecha": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
-      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
     },
     "figures": {
       "version": "3.2.0",
@@ -33449,11 +33522,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
-    },
-    "fn.name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "focus-lock": {
       "version": "0.9.2",
@@ -35647,6 +35715,11 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
+    "joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="
+    },
     "jquery-extend": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/jquery-extend/-/jquery-extend-2.0.3.tgz",
@@ -35949,11 +36022,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/knex-migrate-sql-file/-/knex-migrate-sql-file-1.0.3.tgz",
       "integrity": "sha512-HT61P10DDmFkIn7QW9IWOzXuId8uNzxSc1tJAwkrFD3zAmJMvcfW3XR4euS5jJxjR1R4Yntq0muKimXuvCMjSw=="
-    },
-    "kuler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
     },
     "language-subtag-registry": {
       "version": "0.3.21",
@@ -36546,18 +36614,6 @@
             "strip-ansi": "^4.0.0"
           }
         }
-      }
-    },
-    "logform": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.3.2.tgz",
-      "integrity": "sha512-V6JiPThZzTsbVRspNO6TmHkR99oqYTs8fivMBYQkjZj6rxW92KxtDCPE6IkAk1DNBnYKNkjm4jYBm6JDUcyhOA==",
-      "requires": {
-        "colors": "1.4.0",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "safe-stable-stringify": "^1.1.0",
-        "triple-beam": "^1.3.0"
       }
     },
     "loglevel": {
@@ -37479,38 +37535,6 @@
       "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
       "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
     },
-    "morgan": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
-      "requires": {
-        "basic-auth": "~2.0.1",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -38219,6 +38243,11 @@
       "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
       "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
+    "on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -38238,14 +38267,6 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "one-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "requires": {
-        "fn.name": "1.x.x"
       }
     },
     "onetime": {
@@ -38612,13 +38633,6 @@
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
       "requires": {
         "split2": "^4.1.0"
-      },
-      "dependencies": {
-        "split2": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
-          "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
-        }
       }
     },
     "picocolors": {
@@ -38641,6 +38655,90 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+    },
+    "pino": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.10.0.tgz",
+      "integrity": "sha512-T6R92jy/APDElEuOk0gqa4nds3ZgqFbHde2X0g8XorlyPlVGlr9T5KQphtp72a3ByKOdZMg/gM/0IprpGQfTWg==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.0.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.15.1"
+      },
+      "dependencies": {
+        "safe-stable-stringify": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+          "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
+        }
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "requires": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
+    "pino-http": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-6.6.0.tgz",
+      "integrity": "sha512-PlItaK2MLpoIMLEcClhfb1VQk/o6fKppINl5s6sPE/4rvufkdO3kCSs/92EwrBsB1yssRCQqDV+w1xpYuPVnjg==",
+      "requires": {
+        "fast-url-parser": "^1.1.3",
+        "get-caller-file": "^2.0.5",
+        "pino": "^7.5.0",
+        "pino-std-serializers": "^5.0.0"
+      },
+      "dependencies": {
+        "pino-std-serializers": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-5.2.0.tgz",
+          "integrity": "sha512-tnEZoW/OpiQoL0laBC0CWJ0HPeISW2lrjUK0twYjqdGnggM8ZYk1XG8ucvjMCV0R7kMxO7Z63a27UhpkQw7Rrg=="
+        }
+      }
+    },
+    "pino-pretty": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-7.6.1.tgz",
+      "integrity": "sha512-H7N6ZYkiyrfwBGW9CSjx0uyO9Q2Lyt73881+OTYk8v3TiTdgN92QHrWlEq/LeWw5XtDP64jeSk3mnc6T+xX9/w==",
+      "requires": {
+        "args": "^5.0.1",
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-safe-stringify": "^2.0.7",
+        "joycon": "^3.1.1",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "^0.5.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^2.2.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "2.0.16",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+          "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
+        }
+      }
+    },
+    "pino-std-serializers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
     },
     "pirates": {
       "version": "4.0.4",
@@ -38757,6 +38855,11 @@
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
       "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA=="
     },
+    "process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -38839,7 +38942,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -38886,6 +38988,11 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -39540,6 +39647,11 @@
       "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
       "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg=="
     },
+    "real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg=="
+    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -40048,6 +40160,11 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -40172,11 +40289,6 @@
       "requires": {
         "regexp-tree": "~0.1.1"
       }
-    },
-    "safe-stable-stringify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
-      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -40691,21 +40803,6 @@
         }
       }
     },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-        }
-      }
-    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -40879,6 +40976,14 @@
         }
       }
     },
+    "sonic-boom": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.7.0.tgz",
+      "integrity": "sha512-Ynxp0OGQG91wvDjCbFlRMHbSUmDq7dE/EgDeUJ/j+Q9x1FVkFry20cjLykxRSmlm3QS0B4JYAKE8239XKN4SHQ==",
+      "requires": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -40975,6 +41080,11 @@
         "extend-shallow": "^3.0.0"
       }
     },
+    "split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
+    },
     "sponge-case": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
@@ -41005,11 +41115,6 @@
       "requires": {
         "stackframe": "^1.1.1"
       }
-    },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "stack-utils": {
       "version": "2.0.5",
@@ -41133,6 +41238,11 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "streamsearch": {
       "version": "0.1.2",
@@ -41263,8 +41373,7 @@
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
     "strtok3": {
       "version": "6.2.4",
@@ -41441,16 +41550,19 @@
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
       "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
     },
-    "text-hex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "thread-stream": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
+      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+      "requires": {
+        "real-require": "^0.1.0"
+      }
     },
     "throat": {
       "version": "6.0.1",
@@ -41694,11 +41806,6 @@
       "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
       "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
       "dev": true
-    },
-    "triple-beam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "trough": {
       "version": "2.0.2",
@@ -42476,6 +42583,13 @@
         "vega-schema-url-parser": "^2.2.0",
         "vega-themes": "^2.10.0",
         "vega-tooltip": "^0.27.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "bundled": true,
+          "extraneous": true
+        }
       }
     },
     "vega-encode": {
@@ -43203,50 +43317,6 @@
       "dev": true,
       "requires": {
         "string-width": "^4.0.0"
-      }
-    },
-    "winston": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.5.1.tgz",
-      "integrity": "sha512-tbRtVy+vsSSCLcZq/8nXZaOie/S2tPXPFt4be/Q3vI/WtYwm7rrwidxVw2GRa38FIXcJ1kUM6MOZ9Jmnk3F3UA==",
-      "requires": {
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.3.2",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.4.2"
-      },
-      "dependencies": {
-        "async": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-          "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
-        },
-        "is-stream": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
-        },
-        "safe-stable-stringify": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
-          "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
-        }
-      }
-    },
-    "winston-transport": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.2.tgz",
-      "integrity": "sha512-9jmhltAr5ygt5usgUTQbEiw/7RYXpyUbEAFRCSicIacpUzPkrnQsQZSPGEI12aLK9Jth4zNcYJx3Cvznwrl8pw==",
-      "requires": {
-        "logform": "^2.3.2",
-        "readable-stream": "^3.4.0",
-        "triple-beam": "^1.2.0"
       }
     },
     "wonka": {

--- a/packages/backend/env/.env
+++ b/packages/backend/env/.env
@@ -1,7 +1,7 @@
 # Logging
-LOG_REQUESTS=true
+LOG_REQUESTS=false
 LOG_LEVEL=info
-LOG_FORMAT=default
+LOG_FORMAT=pretty
 LOG_TIMESTAMPS=true
 
 # Server

--- a/packages/backend/env/.env.development
+++ b/packages/backend/env/.env.development
@@ -1,5 +1,5 @@
 # Logging
-LOG_LEVEL=silly
+LOG_LEVEL=trace
 
 # Server
 HOST=localhost

--- a/packages/backend/env/.env.test
+++ b/packages/backend/env/.env.test
@@ -1,5 +1,5 @@
 # Logging
-LOG_LEVEL=silly
+LOG_LEVEL=debug
 
 # Server
 HOST=localhost

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -27,7 +27,6 @@
     "@elastic/elasticsearch": "7.13.0",
     "@octokit/graphql": "4.8.0",
     "@octokit/rest": "18.12.0",
-    "@types/turndown": "5.0.1",
     "apollo-server-core": "3.6.7",
     "apollo-server-express": "3.6.7",
     "aws-sdk": "2.1113.0",
@@ -59,7 +58,6 @@
     "luxon": "2.3.1",
     "mime": "3.0.0",
     "module-alias": "2.2.2",
-    "morgan": "1.10.0",
     "nanoid": "3.3.3",
     "node-cache": "5.1.2",
     "node-html-parser": "3.3.6",
@@ -76,8 +74,7 @@
     "tweetnacl": "1.0.3",
     "tweetnacl-util": "0.15.1",
     "type-graphql": "1.1.1",
-    "typedi": "0.10.0",
-    "winston": "3.5.1"
+    "typedi": "0.10.0"
   },
   "devDependencies": {
     "@types/better-queue": "3.8.3",
@@ -96,11 +93,11 @@
     "@types/luxon": "2.3.1",
     "@types/mime": "2.0.3",
     "@types/module-alias": "2.0.1",
-    "@types/morgan": "1.9.3",
     "@types/node": "16.11.26",
     "@types/parsimmon": "1.10.6",
     "@types/supertest": "2.0.12",
     "@types/tmp": "0.2.3",
+    "@types/turndown": "5.0.1",
     "@types/validator": "13.7.2",
     "@typescript-eslint/eslint-plugin": "5.19.0",
     "@typescript-eslint/parser": "5.19.0",

--- a/packages/backend/src/controllers/avatars.v1.ts
+++ b/packages/backend/src/controllers/avatars.v1.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { AWSError } from 'aws-sdk';
 import { Response, Request } from 'express';
 
 import { streamFromS3 } from '../lib/storage';
 import { getType } from '../shared/mime';
+
+const logger = getLogger('avatars.v1');
 
 /**
  * GET /avatars/:key?content-type=
@@ -27,7 +29,7 @@ import { getType } from '../shared/mime';
 export const getAvatar = async (req: Request, res: Response): Promise<void> => {
   const key = req.params.key;
   const path = `avatars/${key}`;
-  logger.debug(`[AVATARS.V1] Attempting to load avatar: ${path}`);
+  logger.debug(`Attempting to load avatar: ${path}`);
 
   const readable = await streamFromS3(path);
   readable.on('error', (error: AWSError) => {

--- a/packages/backend/src/controllers/drafts.v1.ts
+++ b/packages/backend/src/controllers/drafts.v1.ts
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { AWSError } from 'aws-sdk';
 import { Response, Request } from 'express';
 
 import { streamFromS3 } from '../lib/storage';
+
+const logger = getLogger('drafts.v1');
 
 /**
  * GET /drafts/:draftKey/assets/:attachmentKey?content-type=
  */
 export const getDraftAttachment = async (req: Request, res: Response): Promise<void> => {
   const draftKey = `drafts/${req.params.draftKey}/files/${req.params.attachmentKey}`;
-  logger.debug(`[DRAFTS.V1] Attempting to load draft attachment: ${draftKey}, ${req.params.attachmentKey}`);
+  logger.debug(`Attempting to load draft attachment: ${draftKey}, ${req.params.attachmentKey}`);
 
   const readable = await streamFromS3(draftKey);
   readable.on('error', (error: AWSError) => {

--- a/packages/backend/src/controllers/graphql.v1.ts
+++ b/packages/backend/src/controllers/graphql.v1.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import {
   ApolloServerPluginLandingPageLocalDefault,
   ApolloServerPluginLandingPageProductionDefault
@@ -24,14 +24,16 @@ import { Container } from 'typedi';
 
 import { schema } from '../lib/graphql';
 
+const logger = getLogger('graphql.v1');
+
 const apolloConfig: ApolloServerExpressConfig = {
   schema,
   context: ({ req }) => {
     const requestId = req.id;
 
     // Scoped container
-    logger.silly('[GRAPHQL.V1] Creating Container ' + requestId);
-    const container = Container.of(requestId);
+    logger.trace('Creating Container ' + requestId);
+    const container = Container.of(requestId as string);
 
     const context = {
       container,
@@ -51,7 +53,7 @@ const apolloConfig: ApolloServerExpressConfig = {
         return {
           async willSendResponse(requestContext) {
             // Remove the request's scoped container
-            logger.silly('[GRAPHQL.V1] Terminating Container ' + requestContext.context.requestId);
+            logger.trace('Terminating Container ' + requestContext.context.requestId);
             Container.reset(requestContext.context.requestId);
           }
         };

--- a/packages/backend/src/controllers/insights.v1.ts
+++ b/packages/backend/src/controllers/insights.v1.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { AWSError } from 'aws-sdk';
 import { Response, Request } from 'express';
 
 import { getFromS3, headFromS3 } from '../lib/storage';
 import { getType } from '../shared/mime';
+
+const logger = getLogger('insights.v1');
 
 /**
  * HEAD /insights/:namespace/:name/assets/:filepath
@@ -28,7 +30,7 @@ export const headInsightFile = async (req: Request, res: Response): Promise<void
   const filePath = req.params.filepath + req.params[0];
   const key = `insights/${req.params.namespace}/${req.params.name}/files/${filePath}`;
 
-  logger.debug(`[INSIGHTS.V1] Attempting to HEAD insight attachment: ${filePath}`);
+  logger.debug(`Attempting to HEAD insight attachment: ${filePath}`);
 
   const headObject = await headFromS3(key);
 
@@ -53,7 +55,7 @@ export const getInsightFile = async (req: Request, res: Response): Promise<void>
   const filePath = req.params.filepath + req.params[0];
   const key = `insights/${req.params.namespace}/${req.params.name}/files/${filePath}`;
 
-  logger.debug(`[INSIGHTS.V1] Attempting to load insight attachment: ${filePath}`);
+  logger.debug(`Attempting to load insight attachment: ${filePath}`);
 
   const range = Array.isArray(req.headers['range']) ? req.headers['range'][0] : req.headers['range'];
 

--- a/packages/backend/src/controllers/webhook.v1.ts
+++ b/packages/backend/src/controllers/webhook.v1.ts
@@ -17,12 +17,14 @@
 import { IncomingHttpHeaders } from 'http';
 
 import { RepositoryType } from '@iex/models/repository-type';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { Request, Response } from 'express';
 
 import { defaultElasticsearchClient, ElasticIndex } from '../lib/elasticsearch';
 import insightQueue from '../lib/insight-queue';
 import { InsightSyncTask } from '../models/tasks';
+
+const logger = getLogger('webhook.v1');
 
 type Webhook = any & { headers: IncomingHttpHeaders };
 

--- a/packages/backend/src/environment.ts
+++ b/packages/backend/src/environment.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger, initializeLogger } from '@iex/shared/logger';
 import * as dotenv from 'dotenv-flow';
 import fs from 'fs-extra';
 
@@ -23,7 +23,7 @@ try {
   const packageJson = fs.readJsonSync(__dirname + `/../../../../package.json`);
   process.env.IEX_VERSION = packageJson.version;
 } catch {
-  logger.error('[ENV] Error loading package.json');
+  getLogger('environment').error('Error loading package.json');
   process.env.IEX_VERSION = 'unknown';
 }
 
@@ -39,7 +39,13 @@ if (result.error) {
   throw result.error;
 }
 
+// Initialize logger after loading environment variables
+initializeLogger();
+
+getLogger('environment').info(`NODE_ENV: ${process.env.NODE_ENV}`);
+
 // Configuration validation checks
+// eslint-disable-next-line no-constant-condition
 if (process.env.GITHUB_USE_WEBHOOK === 'true' && process.env.PUBLIC_URL === '') {
-  logger.error('[ENV] Configuration Error: PUBLIC_URL must be set when GITHUB_USE_WEBHOOK is true');
+  getLogger('environment').error('Configuration Error: PUBLIC_URL must be set when GITHUB_USE_WEBHOOK is true');
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -35,8 +35,10 @@ import pRetry from 'p-retry';
 import { bootstrap, defaultKnex } from './lib/db';
 import { deployMappings } from './lib/elasticsearch';
 import { createServer } from './server';
-import logger from '@iex/shared/logger';
 import { syncExampleInsights } from './lib/init';
+import { getLogger } from '@iex/shared/logger';
+
+const logger = getLogger('index');
 
 // Safeguard to prevent the application from crashing.
 // It would be better to catch any promise rejections and handle directly
@@ -52,28 +54,28 @@ process.on('uncaughtException', (uncaughtException) => {
 
 const startup = async (): Promise<Server> => {
   // Deploy Elasticsearch Index mappings
-  logger.debug('[INDEX] Deploying elasticsearch indices');
+  logger.debug('Deploying elasticsearch indices');
   await pRetry(() => deployMappings(), {
     retries: 5,
     factor: 3.86,
     onFailedAttempt: (error) => {
-      logger.warn(`[INDEX] Deploying elasticsearch indices failed (attempt ${error.attemptNumber})`);
+      logger.warn(`Deploying elasticsearch indices failed (attempt ${error.attemptNumber})`);
     }
   });
 
   // Create database pool & apply any schema migrations
-  logger.debug('[INDEX] Bootstrapping database');
+  logger.debug('Bootstrapping database');
   await pRetry(() => bootstrap(defaultKnex), {
     retries: 5,
     factor: 3.86,
     onFailedAttempt: (error) => {
-      logger.warn(`[INDEX] Bootstrapping database failed (attempt ${error.attemptNumber})`);
+      logger.warn(`Bootstrapping database failed (attempt ${error.attemptNumber})`);
       logger.warn(error);
     }
   });
 
   // Start Express server
-  logger.debug('[INDEX] Starting Express server');
+  logger.debug('Starting Express server');
   const app = await createServer();
   const server = app.listen(app.get('port'), () => {
     logger.info(`IEX Server started in ${app.get('env')} mode on port: ${app.get('port')}`);

--- a/packages/backend/src/lib/backends/github.ts
+++ b/packages/backend/src/lib/backends/github.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { graphql as GQ } from '@octokit/graphql';
 import { graphql } from '@octokit/graphql/dist-types/types';
 import { Octokit } from '@octokit/rest';
@@ -35,6 +35,8 @@ import {
   GitHubRepositoryCollaboratorEdge
 } from '../../models/backends/github';
 import { sleep } from '../../shared/util';
+
+const logger = getLogger('github');
 
 /*
  * GitHub GraphQL client configuration
@@ -92,16 +94,16 @@ export async function withRetries<T>(
 
   if (result.status === 202 || result.status == 204) {
     if (retriesLeft > 0) {
-      logger.debug(`[GITHUB] ${result.status} response, retrying request...`);
+      logger.debug(`${result.status} response, retrying request...`);
       await sleep(sleepDuration);
       return withRetries(fn, retriesLeft - 1, sleepDuration * 1.25);
     }
 
-    throw new Error('[GITHUB] Unable to query GitHub successfully before retries ran out...');
+    throw new Error('Unable to query GitHub successfully before retries ran out...');
   }
 
   logger.error(JSON.stringify(result, null, 2));
-  throw new Error('[GITHUB] Error in withRetries() request');
+  throw new Error('Error in withRetries() request');
 }
 
 //
@@ -124,7 +126,7 @@ export async function doesRepositoryExist(
       repo
     });
 
-    logger.info('[GITHUB] Checked Repository existance for ' + repository.nameWithOwner);
+    logger.info('Checked Repository existance for ' + repository.nameWithOwner);
 
     if (repository) {
       return { repository, exists: true };
@@ -185,7 +187,7 @@ export async function getRepository(owner: string, repo: string): Promise<GitHub
     repo
   });
 
-  logger.info('[GITHUB] Retrieved Repository details for ' + repository.nameWithOwner);
+  logger.info('Retrieved Repository details for ' + repository.nameWithOwner);
 
   repository.cloneUrl = repository.url + '.git';
 
@@ -208,11 +210,11 @@ export async function getRepositoryPermissions(
       repo
     });
 
-    logger.info(`[GITHUB] Retrieved Repository permissions of ${repository.viewerPermission} on ${owner}/${repo}`);
+    logger.info(`Retrieved Repository permissions of ${repository.viewerPermission} on ${owner}/${repo}`);
 
     return repository.viewerPermission as GitHubRepositoryPermission;
   } catch (error: any) {
-    logger.debug(`[GITHUB] Unable to retrieve Repository permissions: ${error}`);
+    logger.debug(`Unable to retrieve Repository permissions: ${error}`);
 
     return 'NONE';
   }
@@ -302,7 +304,7 @@ export async function createRepository(token: string, input: CreateRepositoryInp
     input
   });
 
-  logger.info(`[GITHUB] Successfully created GitHub Repository ${input.ownerId}/${input.name}`);
+  logger.info(`Successfully created GitHub Repository ${input.ownerId}/${input.name}`);
   logger.debug(JSON.stringify(createRepository, null, 2));
 
   const repository: GitHubRepository = createRepository.repository;
@@ -334,7 +336,7 @@ export async function cloneTemplateRepository(
   });
 
   logger.info(
-    `[GITHUB] Successfully cloned GitHub Repository ${input.ownerId}/${input.name} from template ${input.repositoryId}`
+    `Successfully cloned GitHub Repository ${input.ownerId}/${input.name} from template ${input.repositoryId}`
   );
   logger.debug(JSON.stringify(cloneTemplateRepository, null, 2));
   const repository: GitHubRepository = cloneTemplateRepository.repository;
@@ -358,7 +360,7 @@ export async function updateRepository(token: string, input: UpdateRepositoryInp
     input
   });
 
-  logger.info(`[GITHUB] Successfully updated GitHub Repository ${input.repositoryId}`);
+  logger.info(`Successfully updated GitHub Repository ${input.repositoryId}`);
   const repository: GitHubRepository = updateRepository.repository;
   repository.cloneUrl = repository.url + '.git';
 
@@ -380,7 +382,7 @@ export async function updateTopics(token: string, input: UpdateTopicsInput): Pro
     input
   })) as GitHubRepositoryStub;
 
-  logger.info(`[GITHUB] Successfully updated GitHub Repository topics ${input.repositoryId}`);
+  logger.info(`Successfully updated GitHub Repository topics ${input.repositoryId}`);
   return repository;
 }
 
@@ -399,7 +401,7 @@ export async function addCollaborator(
     permission
   });
 
-  logger.info(`[GITHUB] Successfully added ${username} to ${owner}/${repo}`);
+  logger.info(`Successfully added ${username} to ${owner}/${repo}`);
 }
 
 export async function removeCollaborator(token: string, owner: string, repo: string, username: string): Promise<void> {
@@ -410,7 +412,7 @@ export async function removeCollaborator(token: string, owner: string, repo: str
     username
   });
 
-  logger.info(`[GITHUB] Successfully removed ${username} from ${owner}/${repo}`);
+  logger.info(`Successfully removed ${username} from ${owner}/${repo}`);
 }
 
 export async function listWebhooks(owner: string, repo: string): Promise<void> {
@@ -420,7 +422,7 @@ export async function listWebhooks(owner: string, repo: string): Promise<void> {
     repo
   });
 
-  logger.info(`[GITHUB] Wehbooks for ${owner}/${repo}: ${JSON.stringify(webhooks, null, 2)}`);
+  logger.info(`Wehbooks for ${owner}/${repo}: ${JSON.stringify(webhooks, null, 2)}`);
 }
 
 export async function createIexWebhook(token: string, owner: string, repo: string): Promise<void> {
@@ -438,7 +440,7 @@ export async function createIexWebhook(token: string, owner: string, repo: strin
     active: true
   });
 
-  logger.info(`[GITHUB] Wehbooks for ${owner}/${repo}: ${JSON.stringify(webhooks, null, 2)}`);
+  logger.info(`Wehbooks for ${owner}/${repo}: ${JSON.stringify(webhooks, null, 2)}`);
 }
 
 export async function archiveRepository(token: string, repositoryId: string): Promise<GitHubRepositoryStub> {
@@ -458,7 +460,7 @@ export async function archiveRepository(token: string, repositoryId: string): Pr
     }
   })) as GitHubRepositoryStub;
 
-  logger.info(`[GITHUB] Successfully archived GitHub repository ${repositoryId}`);
+  logger.info(`Successfully archived GitHub repository ${repositoryId}`);
   return repository;
 }
 
@@ -470,7 +472,7 @@ export async function addUserToOrganization(token: string, org: string, username
     role: 'member'
   });
 
-  logger.info(`[GITHUB] Successfully added ${username} to ${org}`);
+  logger.info(`Successfully added ${username} to ${org}`);
 }
 
 export async function getCollaborators(owner: string, repo: string): Promise<GitHubRepositoryCollaboratorEdge[]> {
@@ -507,17 +509,15 @@ export async function getCollaborators(owner: string, repo: string): Promise<Git
 
       const collaborators = repository.collaborators;
       hasNextPage = collaborators.pageInfo!.hasNextPage;
-      logger.info(`[GITHUB] Retrieved ${collaborators.edges.length} collaborators...`);
+      logger.info(`Retrieved ${collaborators.edges.length} collaborators...`);
       edges.push(...collaborators.edges);
     } catch (error: any) {
       hasNextPage = false;
-      logger.debug(`[GITHUB] Unable to retrieve Repository collaborators: ${error}`);
+      logger.debug(`Unable to retrieve Repository collaborators: ${error}`);
     }
   }
 
-  logger.info(
-    `[GITHUB] ${edges.length} Retrieved collaborators for ${owner}/${repo}: ${JSON.stringify(edges, null, 2)}`
-  );
+  logger.info(`${edges.length} Retrieved collaborators for ${owner}/${repo}: ${JSON.stringify(edges, null, 2)}`);
 
   return edges;
 }

--- a/packages/backend/src/lib/backends/sync.ts
+++ b/packages/backend/src/lib/backends/sync.ts
@@ -16,7 +16,7 @@
 
 import { IndexedInsight } from '@iex/models/indexed/indexed-insight';
 import { RepositoryType } from '@iex/models/repository-type';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 
 import { GitHubRepositorySync } from '../../lib/backends/github.sync';
 import { InsightSyncTask } from '../../models/tasks';
@@ -24,8 +24,10 @@ import { InsightSyncTask } from '../../models/tasks';
 import { BaseSync } from './base.sync';
 import { FileSystemSync } from './file-system.sync';
 
+const logger = getLogger('sync');
+
 export async function syncInsight(insightSyncTask: InsightSyncTask): Promise<IndexedInsight | null> {
-  logger.debug('[SYNC] Syncing Insight');
+  logger.debug('Syncing Insight');
 
   let syncer: BaseSync;
   switch (insightSyncTask.repositoryType) {

--- a/packages/backend/src/lib/db.ts
+++ b/packages/backend/src/lib/db.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import Knex from 'knex';
 import { Model, knexSnakeCaseMappers } from 'objection';
+
+const logger = getLogger('db');
 
 const defaultOptions: Knex.Config = {
   client: 'pg',

--- a/packages/backend/src/lib/import.ts
+++ b/packages/backend/src/lib/import.ts
@@ -15,7 +15,7 @@
  */
 
 import { InsightFileAction } from '@iex/models/insight-file-action';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import isArray from 'lodash/isArray';
 import mergeWith from 'lodash/mergeWith';
 import { nanoid } from 'nanoid';
@@ -26,6 +26,8 @@ import * as turndownPluginGfm from 'turndown-plugin-gfm';
 import { DraftDataInput, DraftKey } from '../models/draft';
 import { AttachmentService } from '../services/attachment.service';
 import { DraftService } from '../services/draft.service';
+
+const logger = getLogger('import');
 
 export type ImportFormat = 'html' | undefined;
 
@@ -152,7 +154,7 @@ export function convertToDraft(request: ImportRequest): DraftDataInput {
     throw new Error('Cannot find a matching converter for this import request');
   }
 
-  logger.debug(`[IMPORT] Importing using the '${converter.name}' converter`);
+  logger.debug(`Importing using the '${converter.name}' converter`);
 
   // Convert request contents
   const draftData = converter.convert(request);
@@ -186,7 +188,7 @@ export function convertToDraft(request: ImportRequest): DraftDataInput {
 }
 
 export async function importToNewDraft(request: ImportRequest): Promise<DraftKey> {
-  logger.info(`[IMPORT] Importing web page ${request.url}`);
+  logger.info(`Importing web page ${request.url}`);
 
   const draftService = new DraftService(new AttachmentService());
   const draftKey = draftService.newDraftKey();

--- a/packages/backend/src/lib/init.ts
+++ b/packages/backend/src/lib/init.ts
@@ -18,9 +18,11 @@ import fs from 'fs';
 import path from 'path';
 
 import { RepositoryType } from '@iex/models/repository-type';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 
 import { syncInsight } from './backends/sync';
+
+const logger = getLogger('init');
 
 export async function syncExampleInsights(): Promise<void> {
   const exampleDirectory = path.join(__dirname, '../../../../examples/insights');

--- a/packages/backend/src/lib/insight-queue.ts
+++ b/packages/backend/src/lib/insight-queue.ts
@@ -15,12 +15,14 @@
  */
 
 import { IndexedInsight } from '@iex/models/indexed/indexed-insight';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import BetterQueue from 'better-queue';
 
 import { InsightSyncTask } from '../models/tasks';
 
 import { syncInsight } from './backends/sync';
+
+const logger = getLogger('insight-queue');
 
 /**
  * Queue processing function.
@@ -32,13 +34,13 @@ const queueHandler: BetterQueue.ProcessFunction<InsightSyncTask, IndexedInsight 
   item: InsightSyncTask,
   callback
 ) => {
-  logger.info(`[INSIGHT QUEUE] Processing item: ${item.owner}/${item.repo}`);
+  logger.info(`Processing item: ${item.owner}/${item.repo}`);
 
   try {
     const insight = await syncInsight(item);
     callback(null, insight);
   } catch (error: any) {
-    logger.error(`[INSIGHT QUEUE] Error syncing insight ${item.owner}/${item.repo}`);
+    logger.error(`Error syncing insight ${item.owner}/${item.repo}`);
     logger.error(JSON.stringify(error, null, 2));
 
     callback(null);

--- a/packages/backend/src/lib/storage.ts
+++ b/packages/backend/src/lib/storage.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { S3 } from 'aws-sdk';
 import type { AWSError, Request } from 'aws-sdk';
 import type { HeadObjectOutput } from 'aws-sdk/clients/s3';
 import type { ReadStream } from 'fs-extra';
+
+const logger = getLogger('storage');
 
 const defaultOptions: S3.Types.ClientConfiguration = {
   region: process.env.S3_REGION,
@@ -52,7 +54,7 @@ export async function writeToS3(body: Buffer | string, key: string): Promise<str
   const response = await defaultS3Client.putObject({ Body: body, Bucket: bucket, Key: key }).promise();
   const uri = `s3://${bucket}/${key}`;
 
-  logger.info(`[STORAGE] S3 file successfully uploaded with Etag: ${response.ETag} and URI: ${uri}`);
+  logger.info(`S3 file successfully uploaded with Etag: ${response.ETag} and URI: ${uri}`);
   return uri;
 }
 
@@ -74,7 +76,7 @@ export async function streamToS3(stream: ReadStream, fileSize: number, key: stri
     .promise();
   const uri = `s3://${bucket}/${key}`;
 
-  logger.info(`[STORAGE] S3 file successfully uploaded with Etag: ${response.ETag} and URI: ${uri}`);
+  logger.info(`S3 file successfully uploaded with Etag: ${response.ETag} and URI: ${uri}`);
   return uri;
 }
 
@@ -88,7 +90,7 @@ export async function streamToS3(stream: ReadStream, fileSize: number, key: stri
 export async function readFromS3(key: string): Promise<Buffer> {
   const bucket = process.env.S3_BUCKET!;
 
-  logger.info(`[STORAGE] Streaming from s3://${bucket}/${key}`);
+  logger.info(`Streaming from s3://${bucket}/${key}`);
   const file = await defaultS3Client.getObject({ Bucket: bucket, Key: key }).promise();
 
   return Buffer.from(file.Body as Buffer);
@@ -105,7 +107,7 @@ export async function readFromS3(key: string): Promise<Buffer> {
 export async function streamFromS3(key: string, range?: string): Promise<ReadStream> {
   const bucket = process.env.S3_BUCKET!;
 
-  logger.info(`[STORAGE] Streaming from s3://${bucket}/${key}`);
+  logger.info(`Streaming from s3://${bucket}/${key}`);
 
   const response = defaultS3Client.getObject({ Bucket: bucket, Key: key, Range: range });
 
@@ -123,7 +125,7 @@ export async function streamFromS3(key: string, range?: string): Promise<ReadStr
 export function getFromS3(key: string, range?: string): Request<S3.Types.GetObjectOutput, AWSError> {
   const bucket = process.env.S3_BUCKET!;
 
-  logger.info(`[STORAGE] Streaming from s3://${bucket}/${key}`);
+  logger.info(`Streaming from s3://${bucket}/${key}`);
 
   return defaultS3Client.getObject({ Bucket: bucket, Key: key, Range: range });
 }
@@ -138,7 +140,7 @@ export function getFromS3(key: string, range?: string): Request<S3.Types.GetObje
 export async function headFromS3(key: string): Promise<HeadObjectOutput | undefined> {
   const bucket = process.env.S3_BUCKET!;
 
-  logger.info(`[STORAGE] Checking existance of s3://${bucket}/${key}`);
+  logger.info(`Checking existance of s3://${bucket}/${key}`);
   try {
     return await defaultS3Client.headObject({ Bucket: bucket, Key: key }).promise();
   } catch (error: any) {
@@ -157,7 +159,7 @@ export async function headFromS3(key: string): Promise<HeadObjectOutput | undefi
 export async function existsInS3(key: string): Promise<boolean> {
   const bucket = process.env.S3_BUCKET!;
 
-  logger.info(`[STORAGE] Checking existance of s3://${bucket}/${key}`);
+  logger.info(`Checking existance of s3://${bucket}/${key}`);
   try {
     await defaultS3Client.headObject({ Bucket: bucket, Key: key }).promise();
     return true;

--- a/packages/backend/src/middleware/gql-error-interceptor.ts
+++ b/packages/backend/src/middleware/gql-error-interceptor.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { DBError, NotNullViolationError, UniqueViolationError } from 'objection';
 import { MiddlewareFn } from 'type-graphql';
+
+const logger = getLogger('gql-error-interceptor');
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const GqlErrorInterceptor: MiddlewareFn<any> = async ({ context, info }, next) => {

--- a/packages/backend/src/middleware/request-id.ts
+++ b/packages/backend/src/middleware/request-id.ts
@@ -21,6 +21,8 @@ import { nanoid } from 'nanoid';
  * Express middleware for attaching a unique ID to each request
  */
 export const requestId = (req: Request, res: Response, next: NextFunction): void => {
-  req.id = nanoid();
+  // pino-http also attaches a unique ID to each request
+  // Only add a new id if one is not already present
+  req.id ??= nanoid();
   next();
 };

--- a/packages/backend/src/middleware/require-auth.ts
+++ b/packages/backend/src/middleware/require-auth.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { NextFunction, Request, Response } from 'express';
+
+const logger = getLogger('require-auth');
 
 /**
  * Middleware for rejecting unauthenticated requests.
@@ -23,7 +25,7 @@ import { NextFunction, Request, Response } from 'express';
  */
 export async function requireAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
   if (req.token === undefined) {
-    logger.error('[REQUIRE_AUTH] Request did not contain authorization, or authorization was invalid.');
+    logger.error('Request did not contain authorization, or authorization was invalid.');
     res.status(401).send('Unauthorized');
     return;
   }

--- a/packages/backend/src/resolvers/activity.resolver.ts
+++ b/packages/backend/src/resolvers/activity.resolver.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { Arg, Authorized, Ctx, FieldResolver, ID, Mutation, Query, Resolver, Root } from 'type-graphql';
 import { Service } from 'typedi';
 
@@ -28,6 +28,8 @@ import { ActivityService } from '../services/activity.service';
 import { InsightService } from '../services/insight.service';
 import { UserService } from '../services/user.service';
 import { toCursor } from '../shared/resolver-utils';
+
+const logger = getLogger('activity.resolver');
 
 @Service()
 @Resolver(() => Activity)
@@ -126,7 +128,7 @@ export class ActivityResolver {
     @Arg('liked') liked: boolean,
     @Ctx() ctx: Context
   ): Promise<Activity> {
-    logger.debug('[ACTIVITY.RESOLVER] Toggling liked for Activity', activityId);
+    logger.debug('Toggling liked for Activity', activityId);
 
     try {
       const activity = await this.activityService.likeActivity(activityId, liked, ctx.user!);

--- a/packages/backend/src/resolvers/admin.resolver.ts
+++ b/packages/backend/src/resolvers/admin.resolver.ts
@@ -15,7 +15,7 @@
  */
 
 import { RepositoryType } from '@iex/models/repository-type';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import pMap from 'p-map';
 import { Resolver, Mutation, Authorized } from 'type-graphql';
 import { Service } from 'typedi';
@@ -26,6 +26,8 @@ import { Permission } from '../models/permission';
 import { User } from '../models/user';
 import { UserService } from '../services/user.service';
 
+const logger = getLogger('admin.resolver');
+
 @Service()
 @Resolver()
 export class AdminResolver {
@@ -34,7 +36,7 @@ export class AdminResolver {
   @Authorized<Permission>({ user: true, admin: true })
   @Mutation(() => Number)
   async syncAllInsights(): Promise<number> {
-    logger.warn('[ADMIN.RESOLVER] Syncing All Insights');
+    logger.warn('Syncing All Insights');
 
     const dbInsights = await DbInsight.query();
 
@@ -63,7 +65,7 @@ export class AdminResolver {
   @Authorized<Permission>({ user: true, admin: true })
   @Mutation(() => Number)
   async syncAllUsers(): Promise<number> {
-    logger.warn('[ADMIN.RESOLVER] Syncing All Users');
+    logger.warn('Syncing All Users');
 
     const users = await User.query();
 

--- a/packages/backend/src/resolvers/attachment.resolver.ts
+++ b/packages/backend/src/resolvers/attachment.resolver.ts
@@ -16,7 +16,7 @@
 
 import path from 'path';
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { GraphQLUpload, FileUpload } from 'graphql-upload';
 import { nanoid } from 'nanoid';
 import { Arg, Authorized, Ctx, Mutation, Resolver } from 'type-graphql';
@@ -29,11 +29,13 @@ import { AvatarUploadResult } from '../models/user';
 import { AttachmentService } from '../services/attachment.service';
 import { getTypeAsync } from '../shared/mime';
 
+const logger = getLogger('attachment.resolver');
+
 @Service()
 @Resolver()
 export class AttachmentResolver {
   constructor(private readonly attachmentService: AttachmentService) {
-    logger.silly('[ATTACHMENT.RESOLVER] Constructing New Attachment Resolver');
+    logger.trace('Constructing New Attachment Resolver');
   }
 
   @Authorized<Permission>({ user: true })
@@ -49,7 +51,7 @@ export class AttachmentResolver {
 
     try {
       const uri = await this.attachmentService.uploadToDraft(draftKey, attachment, createReadStream());
-      logger.debug('[ATTACHMENT_RESOLVER] Wrote stream to S3: ' + uri);
+      logger.debug('Wrote stream to S3: ' + uri);
 
       // Detect the mimeType of the attachment
       const stream = await this.attachmentService.streamFromDraft(draftKey, attachment);
@@ -81,7 +83,7 @@ export class AttachmentResolver {
     const key = this.newAvatarKey() + path.extname(filename);
     try {
       const uri = await this.attachmentService.uploadAvatar(key, size, createReadStream());
-      logger.debug('[ATTACHMENT_RESOLVER] Wrote stream to S3: ' + uri);
+      logger.debug('Wrote stream to S3: ' + uri);
 
       return {
         avatar: key,

--- a/packages/backend/src/resolvers/autocomplete.resolver.ts
+++ b/packages/backend/src/resolvers/autocomplete.resolver.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { Authorized, FieldResolver, Query, Resolver } from 'type-graphql';
 import { Service } from 'typedi';
 
@@ -22,6 +22,8 @@ import { ElasticIndex, uniqueTerms } from '../lib/elasticsearch';
 import { UniqueValue, AutocompleteResults } from '../models/autocomplete';
 import { Permission } from '../models/permission';
 import { UserService } from '../services/user.service';
+
+const logger = getLogger('autocomplete.resolver');
 
 @Service()
 @Resolver(() => AutocompleteResults)

--- a/packages/backend/src/resolvers/comment.resolver.ts
+++ b/packages/backend/src/resolvers/comment.resolver.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { Arg, Authorized, Ctx, FieldResolver, ID, Mutation, Query, Resolver, Root } from 'type-graphql';
 import { Service } from 'typedi';
 
@@ -27,6 +27,8 @@ import { CommentService } from '../services/comment.service';
 import { InsightService } from '../services/insight.service';
 import { UserService } from '../services/user.service';
 import { fromGlobalId, toCursor } from '../shared/resolver-utils';
+
+const logger = getLogger('comment.resolver');
 
 @Service()
 @Resolver(() => Comment)
@@ -142,7 +144,7 @@ export class CommentResolver {
   @Authorized<Permission>({ user: true })
   @Mutation(() => Comment)
   async addComment(@Arg('comment') comment: CommentInput, @Ctx() ctx: Context): Promise<Comment> {
-    logger.debug('[COMMENT.RESOLVER] Adding new Comment', comment);
+    logger.debug('Adding new Comment', comment);
 
     const { insightId, commentText, parentCommentId } = comment;
     const [, dbInsightId] = fromGlobalId(insightId!);
@@ -174,7 +176,7 @@ export class CommentResolver {
     @Arg('comment') comment: CommentInput,
     @Ctx() ctx: Context
   ): Promise<Comment> {
-    logger.debug('[COMMENT.RESOLVER] Updating Comment', comment);
+    logger.debug('Updating Comment', comment);
 
     const [, dbCommentId] = fromGlobalId(commentId);
     const newComment: Partial<Comment> = {
@@ -193,7 +195,7 @@ export class CommentResolver {
   @Authorized<Permission>({ user: true })
   @Mutation(() => Comment)
   async deleteComment(@Arg('commentId', () => ID) commentId: string, @Ctx() ctx: Context): Promise<Comment> {
-    logger.debug('[COMMENT.RESOLVER] Deleting Comment', commentId);
+    logger.debug('Deleting Comment', commentId);
 
     const [, dbCommentId] = fromGlobalId(commentId);
 
@@ -213,7 +215,7 @@ export class CommentResolver {
     @Arg('liked') liked: boolean,
     @Ctx() ctx: Context
   ): Promise<Comment> {
-    logger.debug('[COMMENT.RESOLVER] Toggling liked for Comment', commentId);
+    logger.debug('Toggling liked for Comment', commentId);
 
     const [, dbCommentId] = fromGlobalId(commentId);
 

--- a/packages/backend/src/resolvers/draft.resolver.ts
+++ b/packages/backend/src/resolvers/draft.resolver.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { Arg, Authorized, Ctx, FieldResolver, ID, Mutation, Query, Resolver, Root } from 'type-graphql';
 import { Service } from 'typedi';
 
@@ -27,6 +27,8 @@ import { DraftService } from '../services/draft.service';
 import { InsightService } from '../services/insight.service';
 import { UserService } from '../services/user.service';
 import { fromGlobalId } from '../shared/resolver-utils';
+
+const logger = getLogger('draft.resolver');
 
 @Service()
 @Resolver(() => Draft)
@@ -98,7 +100,7 @@ export class DraftResolver {
   @Authorized<Permission>({ user: true })
   @Mutation(() => Draft)
   async upsertDraft(@Arg('draft') draft: DraftInput, @Ctx() ctx: Context): Promise<Draft> {
-    logger.debug('[DRAFT.RESOLVER] Upserting Draft', draft);
+    logger.debug('Upserting Draft', draft);
 
     try {
       const upserted = await this.draftService.upsertDraft(draft, ctx.user!);
@@ -117,7 +119,7 @@ export class DraftResolver {
   @Authorized<Permission>({ user: true })
   @Mutation(() => Draft)
   async deleteDraft(@Arg('draftKey') draftKey: DraftKey, @Ctx() ctx: Context): Promise<Draft> {
-    logger.debug('[DRAFT.RESOLVER] Deleting Draft', draftKey);
+    logger.debug('Deleting Draft', draftKey);
 
     try {
       return await this.draftService.deleteDraft(draftKey, ctx.user!);
@@ -131,7 +133,7 @@ export class DraftResolver {
   @Authorized<Permission>({ user: true, github: true })
   @Mutation(() => Draft)
   async cloneInsight(@Arg('insightId', () => ID) insightId: string, @Ctx() ctx: Context): Promise<Draft> {
-    logger.debug('[INSIGHT.RESOLVER] Cloning Insight', insightId);
+    logger.debug('Cloning Insight', insightId);
 
     try {
       const [, dbInsightId] = fromGlobalId(insightId);

--- a/packages/backend/src/resolvers/insight.resolver.ts
+++ b/packages/backend/src/resolvers/insight.resolver.ts
@@ -17,7 +17,7 @@
 import { PersonType } from '@iex/models/person-type';
 import { RepositoryPermission } from '@iex/models/repository-permission';
 import { RepositoryType } from '@iex/models/repository-type';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { ResolveTree } from 'graphql-parse-resolve-info';
 import { Arg, Authorized, Ctx, ID, FieldResolver, Mutation, Query, Resolver, Root } from 'type-graphql';
 import { Service } from 'typedi';
@@ -40,6 +40,8 @@ import { InsightService } from '../services/insight.service';
 import { UserService } from '../services/user.service';
 import { Fields } from '../shared/field-parameter-decorator';
 import { fromGlobalId, toCursor } from '../shared/resolver-utils';
+
+const logger = getLogger('insight.resolver');
 
 @Service()
 @Resolver(() => Insight)
@@ -105,7 +107,7 @@ export class InsightResolver {
     @Fields() fields: { Insight: { [str: string]: ResolveTree } },
     @Arg('fullName') fullName: string
   ): Promise<Insight | null> {
-    logger.debug(`[INSIGHT.RESOLVER] Insight by Full Name: ${fullName}`);
+    logger.debug(`Insight by Full Name: ${fullName}`);
     try {
       const insight = (await this.insightService.getInsightByFullName(
         fullName,
@@ -125,7 +127,7 @@ export class InsightResolver {
     @Arg('name') name: string,
     @Arg('namespace') namespace: string
   ): Promise<ValidateInsightName> {
-    logger.debug(`[INSIGHT.RESOLVER] Insight by Display Name: ${name}`);
+    logger.debug(`Insight by Display Name: ${name}`);
     try {
       const validation = await this.insightService.validateInsightName(name, namespace);
       return validation;
@@ -296,7 +298,7 @@ export class InsightResolver {
   @Authorized<Permission>({ user: true, github: true })
   @Mutation(() => Insight)
   async publishDraft(@Arg('draftKey') draftKey: string, @Ctx() ctx: Context): Promise<Insight> {
-    logger.debug('[INSIGHT.RESOLVER] Publishing Draft Key', draftKey);
+    logger.debug('Publishing Draft Key', draftKey);
 
     try {
       const draft = await this.draftService.getDraft(draftKey);
@@ -368,7 +370,7 @@ export class InsightResolver {
     @Arg('liked') liked: boolean,
     @Ctx() ctx: Context
   ): Promise<Insight> {
-    logger.debug('[INSIGHT.RESOLVER] Toggling liked for Insight', insightId);
+    logger.debug('Toggling liked for Insight', insightId);
 
     try {
       const [, dbInsightId] = fromGlobalId(insightId);
@@ -391,7 +393,7 @@ export class InsightResolver {
     @Arg('insightName') insightName: string,
     @Ctx() ctx: Context
   ): Promise<Activity> {
-    logger.debug('[INSIGHT.RESOLVER] Recording view Insight', insightId);
+    logger.debug('Recording view Insight', insightId);
 
     try {
       const [, dbInsightId] = fromGlobalId(insightId);
@@ -412,7 +414,7 @@ export class InsightResolver {
   @Authorized<Permission>({ user: true })
   @Mutation(() => Insight)
   async syncInsight(@Arg('insightId', () => ID) insightId: string): Promise<Insight | null> {
-    logger.debug('[INSIGHT.RESOLVER] Syncing Insight', insightId);
+    logger.debug('Syncing Insight', insightId);
 
     const [, dbInsightId] = fromGlobalId(insightId);
     const dbInsight = await DbInsight.query().where('insightId', dbInsightId).first();
@@ -441,7 +443,7 @@ export class InsightResolver {
   @Authorized<Permission>({ user: true, github: true })
   @Mutation(() => ID)
   async deleteInsight(@Arg('insightId', () => ID) insightId: string, @Ctx() ctx: Context): Promise<string> {
-    logger.debug('[INSIGHT.RESOLVER] Deleting Insight', insightId);
+    logger.debug('Deleting Insight', insightId);
 
     try {
       const [, dbInsightId] = fromGlobalId(insightId);
@@ -466,7 +468,7 @@ export class InsightResolver {
     @Fields() fields: { Insight: { [str: string]: ResolveTree } },
     @Arg('permission', { nullable: true }) permission?: RepositoryPermission
   ): Promise<Insight> {
-    logger.debug('[INSIGHT.RESOLVER] Adding Collaborator', insightId);
+    logger.debug('Adding Collaborator', insightId);
 
     try {
       const [, dbInsightId] = fromGlobalId(insightId);
@@ -494,7 +496,7 @@ export class InsightResolver {
     @Ctx() ctx: Context,
     @Fields() fields: { Insight: { [str: string]: ResolveTree } }
   ): Promise<Insight> {
-    logger.debug('[INSIGHT.RESOLVER] Removing Collaborator', insightId);
+    logger.debug('Removing Collaborator', insightId);
 
     try {
       const [, dbInsightId] = fromGlobalId(insightId);

--- a/packages/backend/src/resolvers/insights.resolver.ts
+++ b/packages/backend/src/resolvers/insights.resolver.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { ResolveTree } from 'graphql-parse-resolve-info';
 import { Arg, Authorized, Query, Resolver } from 'type-graphql';
 import { Service } from 'typedi';
@@ -23,6 +23,8 @@ import { searchInsights } from '../lib/elasticsearch';
 import { InsightSearch, InsightSearchResults } from '../models/insight-search';
 import { Permission } from '../models/permission';
 import { Fields } from '../shared/field-parameter-decorator';
+
+const logger = getLogger('insight.resolver');
 
 @Service()
 @Resolver()

--- a/packages/backend/src/resolvers/news.resolver.ts
+++ b/packages/backend/src/resolvers/news.resolver.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { Arg, Authorized, Ctx, FieldResolver, ID, Mutation, Query, Resolver, Root } from 'type-graphql';
 import { Service } from 'typedi';
 
@@ -25,6 +25,8 @@ import { User, UserConnection } from '../models/user';
 import { NewsService } from '../services/news.service';
 import { UserService } from '../services/user.service';
 import { fromCursor, fromGlobalId, toCursor } from '../shared/resolver-utils';
+
+const logger = getLogger('news.resolver');
 
 @Service()
 @Resolver(() => News)
@@ -146,7 +148,7 @@ export class NewsResolver {
   @Authorized<Permission>({ user: true, admin: true })
   @Mutation(() => News)
   async addNews(@Arg('news') news: NewsInput, @Ctx() ctx: Context): Promise<News> {
-    logger.debug('[NEWS.RESOLVER] Adding new News', news);
+    logger.debug('Adding new News', news);
 
     try {
       return await this.newsService.createNews(news, ctx.user!);
@@ -160,7 +162,7 @@ export class NewsResolver {
   @Authorized<Permission>({ user: true, admin: true })
   @Mutation(() => News)
   async updateNews(@Arg('newsId', () => ID) newsId: string, @Arg('news') news: NewsInput): Promise<News> {
-    logger.debug('[NEWS.RESOLVER] Updating News', news);
+    logger.debug('Updating News', news);
 
     const [, dbNewsId] = fromGlobalId(newsId);
     try {
@@ -175,7 +177,7 @@ export class NewsResolver {
   @Authorized<Permission>({ user: true, admin: true })
   @Mutation(() => News)
   async deleteNews(@Arg('newsId', () => ID) newsId: string): Promise<News> {
-    logger.debug('[NEWS.RESOLVER] Deleting News', newsId);
+    logger.debug('Deleting News', newsId);
 
     const [, dbNewsId] = fromGlobalId(newsId);
 
@@ -195,7 +197,7 @@ export class NewsResolver {
     @Arg('liked') liked: boolean,
     @Ctx() ctx: Context
   ): Promise<News> {
-    logger.debug('[NEWS.RESOLVER] Toggling liked for News', newsId);
+    logger.debug('Toggling liked for News', newsId);
 
     const [, dbNewsId] = fromGlobalId(newsId);
 

--- a/packages/backend/src/resolvers/repository.resolver.ts
+++ b/packages/backend/src/resolvers/repository.resolver.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { Resolver, FieldResolver, Root, ResolverInterface } from 'type-graphql';
 import { Service } from 'typedi';
 
 import { Repository } from '../models/repository';
 import { InsightService } from '../services/insight.service';
+
+const logger = getLogger('repository.resolver');
 
 @Service()
 @Resolver(() => Repository)
@@ -28,7 +30,7 @@ export class RepositoryResolver implements ResolverInterface<Repository> {
 
   @FieldResolver()
   async isMissing(@Root() repository: Repository): Promise<boolean> {
-    logger.debug('[REPOSITORY.RESOLVER] Fetching isMissing');
+    logger.debug('Fetching isMissing');
 
     return this.insightService.isRepositoryMissing(repository);
   }

--- a/packages/backend/src/resolvers/template.resolver.ts
+++ b/packages/backend/src/resolvers/template.resolver.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { ResolveTree } from 'graphql-parse-resolve-info';
 import { Arg, Authorized, ID, Query, Resolver } from 'type-graphql';
 import { Service } from 'typedi';
@@ -26,6 +26,7 @@ import { TemplateService } from '../services/template.service';
 import { Fields } from '../shared/field-parameter-decorator';
 import { fromGlobalId } from '../shared/resolver-utils';
 
+const logger = getLogger('template.resolver');
 @Service()
 @Resolver()
 export class TemplateResolver {
@@ -61,7 +62,7 @@ export class TemplateResolver {
     @Arg('templateId', () => ID, { nullable: true }) templateId?: string,
     @Arg('fullName', { nullable: true }) fullName?: string
   ): Promise<Insight | null> {
-    logger.debug(`[TEMPLATE.RESOLVER] Template by id (${templateId}) / name (${fullName})`);
+    logger.debug(`Template by id (${templateId}) / name (${fullName})`);
     try {
       let template: Insight | null = null;
 

--- a/packages/backend/src/resolvers/user.resolver.ts
+++ b/packages/backend/src/resolvers/user.resolver.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { ResolveTree } from 'graphql-parse-resolve-info';
 import { Arg, Args, Authorized, Ctx, FieldResolver, Mutation, Query, Resolver, Root } from 'type-graphql';
 import { Service } from 'typedi';
@@ -33,6 +33,8 @@ import { ActivityService } from '../services/activity.service';
 import { OAuthService } from '../services/oauth.service';
 import { UserService } from '../services/user.service';
 import { Fields } from '../shared/field-parameter-decorator';
+
+const logger = getLogger('user.resolver');
 
 @Service()
 @Resolver(() => User)
@@ -166,7 +168,7 @@ export class UserResolver {
     // Determine if user is an admin or not
     user.isAdmin = ctx.user?.isAdmin ?? false;
 
-    logger.debug(`[LOGIN] ${user.userName} logged in...`);
+    logger.debug(`${user.userName} logged in...`);
 
     if (process.env.ACTIVITIES_IGNORE_LOGIN === 'false') {
       const { loginCount } = user;

--- a/packages/backend/src/resolvers/users.resolver.ts
+++ b/packages/backend/src/resolvers/users.resolver.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { Resolver, Query, Authorized } from 'type-graphql';
 import { Service } from 'typedi';
 
 import { Permission } from '../models/permission';
 import { User } from '../models/user';
+
+const logger = getLogger('users.resolver');
 
 @Service()
 @Resolver()

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -18,15 +18,17 @@ import 'express-async-errors';
 
 import path from 'path';
 
-import logger from '@iex/shared/logger';
+import { getLogger, httpLogger } from '@iex/shared/logger';
 import compression from 'compression';
 import express from 'express';
 import type { NextFunction, Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import morgan from 'morgan';
+import { nanoid } from 'nanoid';
 
 import { security } from './middleware/security';
 import { createRouter } from './router';
+
+const logger = getLogger('server');
 
 export async function createServer(): Promise<express.Express> {
   // Init express
@@ -54,7 +56,11 @@ export async function createServer(): Promise<express.Express> {
   app.use(express.urlencoded({ extended: true }));
 
   if (process.env.LOG_REQUESTS === 'true') {
-    app.use(morgan('dev'));
+    app.use(
+      httpLogger({
+        genReqId: () => nanoid()
+      })
+    );
   }
 
   // Add APIs

--- a/packages/backend/src/services/comment.service.ts
+++ b/packages/backend/src/services/comment.service.ts
@@ -15,7 +15,7 @@
  */
 
 import { sort } from '@iex/shared/dataloader-util';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import DataLoader from 'dataloader';
 import { raw, ref } from 'objection';
 import { Service } from 'typedi';
@@ -28,11 +28,13 @@ import { UserComment } from '../models/user-comment';
 
 import { ActivityService } from './activity.service';
 
+const logger = getLogger('comment.service');
+
 @Service()
 export class CommentService {
   private userCommentLoader: DataLoader<{ commentId: number; userId: number }, UserComment> = new DataLoader(
     async (tuples) => {
-      logger.silly('[COMMENT.SERVICE] userCommentLoader');
+      logger.trace('userCommentLoader');
 
       const existingUserComments = await UserComment.query().whereInComposite(
         ['commentId', 'userId'],
@@ -44,7 +46,7 @@ export class CommentService {
   );
 
   private likeCountLoader: DataLoader<number, number> = new DataLoader(async (commentIds) => {
-    logger.silly('[COMMENT.SERVICE] likeCountLoader');
+    logger.trace('likeCountLoader');
 
     const result = await UserComment.query()
       .whereIn('commentId', commentIds as number[])
@@ -57,7 +59,7 @@ export class CommentService {
   });
 
   private likedByLoader: DataLoader<number, number[]> = new DataLoader(async (commentIds) => {
-    logger.silly('[COMMENT.SERVICE] likedByLoader');
+    logger.trace('likedByLoader');
 
     const result = await UserComment.query()
       .whereIn('commentId', commentIds as number[])
@@ -69,7 +71,7 @@ export class CommentService {
   });
 
   constructor(private readonly activityService: ActivityService) {
-    logger.silly('[COMMENT.SERVICE] Constructing New Comment Service');
+    logger.trace('Constructing New Comment Service');
   }
 
   /**
@@ -94,7 +96,7 @@ export class CommentService {
    * @param user User
    */
   async doesUserLikeComment(commentId: number, user: User): Promise<boolean> {
-    logger.silly('[COMMENT.SERVICE] doesUserLikeComment ' + commentId);
+    logger.trace('doesUserLikeComment ' + commentId);
 
     if (user == null) {
       return false;
@@ -111,7 +113,7 @@ export class CommentService {
    * @param commentId Comment ID
    */
   async likeCount(commentId: number): Promise<number> {
-    logger.silly('[COMMENT.SERVICE] likeCount for ' + commentId);
+    logger.trace('likeCount for ' + commentId);
 
     return this.likeCountLoader.load(commentId);
   }
@@ -122,7 +124,7 @@ export class CommentService {
    * @param commentId Comment ID
    */
   async likedBy(commentId: number): Promise<number[]> {
-    logger.silly('[COMMENT.SERVICE] likedBy for ' + commentId);
+    logger.trace('likedBy for ' + commentId);
 
     return this.likedByLoader.load(commentId);
   }

--- a/packages/backend/src/services/draft.service.ts
+++ b/packages/backend/src/services/draft.service.ts
@@ -16,7 +16,7 @@
 
 import { IndexedInsight } from '@iex/models/indexed/indexed-insight';
 import { InsightFileAction } from '@iex/models/insight-file-action';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { nanoid } from 'nanoid';
 import pMap from 'p-map';
 import { Service } from 'typedi';
@@ -27,10 +27,12 @@ import { User } from '../models/user';
 import { AttachmentService } from '../services/attachment.service';
 import { fromGlobalId } from '../shared/resolver-utils';
 
+const logger = getLogger('draft.service');
+
 @Service()
 export class DraftService {
   constructor(private readonly attachmentService: AttachmentService) {
-    logger.silly('[DRAFT.SERVICE] Constructing New Draft Service');
+    logger.trace('[DRAFT.SERVICE] Constructing New Draft Service');
   }
 
   newDraftKey(): string {
@@ -95,10 +97,10 @@ export class DraftService {
     }
 
     if (existingDraft != undefined) {
-      logger.silly('Draft does exist in database');
+      logger.trace('Draft does exist in database');
       return await existingDraft.$query().patchAndFetch(draftRemains);
     } else {
-      logger.silly('Draft does not exist in database');
+      logger.trace('Draft does not exist in database');
       return await Draft.query().insert({
         ...draftRemains,
         createdByUserId: user?.userId
@@ -120,7 +122,7 @@ export class DraftService {
         throw new Error('Not allowed');
       }
 
-      logger.silly('Draft does exist in database');
+      logger.trace('Draft does exist in database');
       const count = await existingDraft.$query().delete();
       if (count !== 1) {
         throw new Error('Unexpectedly, Draft not deleted');
@@ -137,7 +139,7 @@ export class DraftService {
    * @param sourceInsight Source Insight
    */
   async cloneInsight(sourceInsight: IndexedInsight, user: User): Promise<Draft> {
-    logger.info(`[INSIGHT.SERVICE] Cloning ${sourceInsight.fullName} into a new Draft`);
+    logger.info(`Cloning ${sourceInsight.fullName} into a new Draft`);
 
     const draftKey = nanoid();
     const draft: DraftInput = {

--- a/packages/backend/src/services/news.service.ts
+++ b/packages/backend/src/services/news.service.ts
@@ -15,7 +15,7 @@
  */
 
 import { sort } from '@iex/shared/dataloader-util';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import DataLoader from 'dataloader';
 import { raw, ref } from 'objection';
 import { Service } from 'typedi';
@@ -28,10 +28,12 @@ import { UserNews } from '../models/user-news';
 
 import { ActivityService } from './activity.service';
 
+const logger = getLogger('news.service');
+
 @Service()
 export class NewsService {
   private userNewsLoader: DataLoader<{ newsId: number; userId: number }, UserNews> = new DataLoader(async (tuples) => {
-    logger.silly('[NEWS.SERVICE] userNewsLoader');
+    logger.trace('userNewsLoader');
 
     const existingUserNews = await UserNews.query().whereInComposite(
       ['newsId', 'userId'],
@@ -42,7 +44,7 @@ export class NewsService {
   });
 
   private likeCountLoader: DataLoader<number, number> = new DataLoader(async (newsIds) => {
-    logger.silly('[NEWS.SERVICE] likeCountLoader');
+    logger.trace('likeCountLoader');
 
     const result = await UserNews.query()
       .whereIn('newsId', newsIds as number[])
@@ -55,7 +57,7 @@ export class NewsService {
   });
 
   private likedByLoader: DataLoader<number, number[]> = new DataLoader(async (newsIds) => {
-    logger.silly('[NEWS.SERVICE] likedByLoader');
+    logger.trace('likedByLoader');
 
     const result = await UserNews.query()
       .whereIn('newsId', newsIds as number[])
@@ -67,7 +69,7 @@ export class NewsService {
   });
 
   constructor(private readonly activityService: ActivityService) {
-    logger.silly('[NEWS.SERVICE] Constructing New News Service');
+    logger.trace('Constructing New News Service');
   }
 
   /**
@@ -92,7 +94,7 @@ export class NewsService {
    * @param user User
    */
   async doesUserLikeNews(newsId: number, user: User): Promise<boolean> {
-    logger.silly('[NEWS.SERVICE] doesUserLikeNews ' + newsId);
+    logger.trace('doesUserLikeNews ' + newsId);
 
     if (user == null) {
       return false;
@@ -109,7 +111,7 @@ export class NewsService {
    * @param newsId News ID
    */
   async likeCount(newsId: number): Promise<number> {
-    logger.silly('[NEWS.SERVICE] likeCount for ' + newsId);
+    logger.trace('likeCount for ' + newsId);
 
     return this.likeCountLoader.load(newsId);
   }
@@ -120,7 +122,7 @@ export class NewsService {
    * @param newsId News ID
    */
   async likedBy(newsId: number): Promise<number[]> {
-    logger.silly('[NEWS.SERVICE] likedBy for ' + newsId);
+    logger.trace('likedBy for ' + newsId);
 
     return this.likedByLoader.load(newsId);
   }

--- a/packages/backend/src/services/template.service.ts
+++ b/packages/backend/src/services/template.service.ts
@@ -18,7 +18,7 @@ import { RequestParams } from '@elastic/elasticsearch';
 import { SearchBody, SearchResponse } from '@iex/models/elasticsearch';
 import { IndexedInsight } from '@iex/models/indexed/indexed-insight';
 import { ItemType } from '@iex/models/item-type';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { Service } from 'typedi';
 
 import {
@@ -29,13 +29,15 @@ import {
 } from '../lib/elasticsearch';
 import { Insight } from '../models/insight';
 
+const logger = getLogger('template.service');
+
 @Service()
 export class TemplateService {
   // These fields will always be requested even if not included in _source args
   private requiredSourceFields = ['insightId', 'fullName'];
 
   constructor() {
-    logger.silly('[TEMPLATE.SERVICE] Constructing New Template Service');
+    logger.trace('Constructing New Template Service');
   }
 
   /**

--- a/packages/backend/src/shared/slugify.ts
+++ b/packages/backend/src/shared/slugify.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import deburr from 'lodash/deburr';
 import kebabCase from 'lodash/kebabCase';
+
+const logger = getLogger('slugify');
 
 /**
  * Converts an Insight Name into a slug-ready version

--- a/packages/backend/src/types/express.d.ts
+++ b/packages/backend/src/types/express.d.ts
@@ -20,8 +20,6 @@ import { OAuthUserInfo } from '../models/oauth-user-info';
 declare global {
   namespace Express {
     export interface Request {
-      id: string;
-
       token?: string;
       oAuthUserInfo?: OAuthUserInfo;
       user?: any;

--- a/packages/convertbot/env/.env
+++ b/packages/convertbot/env/.env
@@ -1,7 +1,7 @@
 # Logging
-LOG_REQUESTS=true
+LOG_REQUESTS=false
 LOG_LEVEL=info
-LOG_FORMAT=default
+LOG_FORMAT=pretty
 LOG_TIMESTAMPS=true
 
 # Server

--- a/packages/convertbot/env/.env.development
+++ b/packages/convertbot/env/.env.development
@@ -1,5 +1,5 @@
 # Logging
-LOG_LEVEL=silly
+LOG_LEVEL=trace
 
 # Server
 HOST=localhost

--- a/packages/convertbot/env/.env.test
+++ b/packages/convertbot/env/.env.test
@@ -1,2 +1,2 @@
 # Logging
-LOG_LEVEL=silly
+LOG_LEVEL=debug

--- a/packages/convertbot/package.json
+++ b/packages/convertbot/package.json
@@ -30,7 +30,6 @@
     "helmet": "5.0.2",
     "http-status-codes": "2.2.0",
     "module-alias": "2.2.2",
-    "morgan": "1.10.0",
     "reflect-metadata": "0.1.13",
     "tmp-promise": "3.0.3"
   },
@@ -40,7 +39,6 @@
     "@types/express": "4.17.13",
     "@types/jest": "27.4.1",
     "@types/module-alias": "2.0.1",
-    "@types/morgan": "1.9.3",
     "@types/node": "16.11.26",
     "@types/tmp": "0.2.3",
     "@typescript-eslint/eslint-plugin": "5.19.0",

--- a/packages/convertbot/src/index.ts
+++ b/packages/convertbot/src/index.ts
@@ -32,7 +32,9 @@ import './environment';
 import type { Server } from 'http';
 
 import app from './server';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
+
+const logger = getLogger('index');
 
 // Safeguard to prevent the application from crashing.
 process.on('uncaughtException', (uncaughtException) => {
@@ -42,7 +44,7 @@ process.on('uncaughtException', (uncaughtException) => {
 
 const startup = async (): Promise<Server> => {
   // Start Express server
-  logger.debug('[INDEX] Starting Express server');
+  logger.debug('Starting Express server');
   const server = app.listen(app.get('port'), () => {
     logger.info(`IEX Convertbot started in ${app.get('env')} mode on port: ${app.get('port')}`);
   });

--- a/packages/convertbot/src/lib/exec.ts
+++ b/packages/convertbot/src/lib/exec.ts
@@ -16,19 +16,21 @@
 
 import * as childProcess from 'child_process';
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
+
+const logger = getLogger('exec');
 
 export const exec = async (command: string): Promise<{ stdout: string; stderr: string }> => {
   return new Promise((resolve, reject) => {
-    logger.silly(`[EXEC] Executing command ${command}`);
+    logger.trace(`Executing command ${command}`);
     childProcess.exec(command, (err, stdout, stderr) => {
-      logger.silly(`[EXEC] stdout: `);
-      logger.silly(stdout);
-      logger.silly(`[EXEC] stderr: `);
-      logger.silly(stderr);
+      logger.trace(`stdout: `);
+      logger.trace(stdout);
+      logger.trace(`stderr: `);
+      logger.trace(stderr);
 
       if (err) {
-        logger.error('[EXEC] Failed: ' + err);
+        logger.error('Failed: ' + err);
         reject(err);
       }
 

--- a/packages/convertbot/src/server.ts
+++ b/packages/convertbot/src/server.ts
@@ -16,17 +16,18 @@
 
 import 'express-async-errors';
 
-import logger from '@iex/shared/logger';
+import { getLogger, httpLogger } from '@iex/shared/logger';
 import compression from 'compression';
 import type { NextFunction, Request, Response } from 'express';
 import express from 'express';
 import { StatusCodes } from 'http-status-codes';
-import morgan from 'morgan';
 
 import { registerConversionMappings } from './conversions';
 import { Convertbot } from './lib/convertbot';
 import { security } from './middleware/security';
 import router from './router';
+
+const logger = getLogger('server');
 
 // Init express
 const app = express();
@@ -53,7 +54,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 if (process.env.LOG_REQUESTS === 'true') {
-  app.use(morgan('dev'));
+  app.use(httpLogger());
 }
 
 // Add APIs

--- a/packages/mq/src/message-queue.ts
+++ b/packages/mq/src/message-queue.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import { SQS } from 'aws-sdk';
 import { Consumer } from 'sqs-consumer';
+
+const logger = getLogger('message-queue');
 
 export interface SQSMessageQueueOptions {
   region: string;
@@ -46,31 +48,31 @@ export class MessageQueue {
       queueUrl: this.options.queueUrl,
       region: this.options.region,
       handleMessage: async (message) => {
-        logger.silly('[MESSAGE_QUEUE] Received message: ' + message.MessageId);
+        logger.trace('Received message: ' + message.MessageId);
 
         let body: T;
         try {
           body = JSON.parse(message.Body!);
         } catch (error: any) {
-          logger.error('[MESSAGE_QUEUE] Unable to parse body of message: ' + message.Body);
-          logger.error('[MESSAGE_QUEUE] Error: ' + error);
+          logger.error('Unable to parse body of message: ' + message.Body);
+          logger.error('Error: ' + error);
         }
 
         try {
           await handler(body!, message);
         } catch (error: any) {
-          logger.error('[MESSAGE_QUEUE] Error: ' + error);
+          logger.error('Error: ' + error);
           throw error;
         }
       }
     });
 
     consumer.on('error', (error) => {
-      logger.error('[MESSAGE_QUEUE] ' + error.message);
+      logger.error(error.message);
     });
 
     consumer.on('processing_error', (error) => {
-      logger.error('[MESSAGE_QUEUE] ' + error.message);
+      logger.error(error.message);
     });
 
     consumer.start();

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,7 +24,9 @@
     "fs-extra": "10.0.1",
     "lodash": "4.17.21",
     "parsimmon": "1.18.1",
-    "winston": "3.5.1"
+    "pino": "7.10.0",
+    "pino-http": "6.6.0",
+    "pino-pretty": "7.6.1"
   },
   "devDependencies": {
     "@types/fs-extra": "9.0.13",

--- a/packages/shared/src/storage.ts
+++ b/packages/shared/src/storage.ts
@@ -19,7 +19,9 @@ import type { Readable } from 'stream';
 import { S3 } from 'aws-sdk';
 import type { ReadStream } from 'fs-extra';
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
+
+const logger = getLogger('storage');
 
 export type StorageOptions = S3.Types.ClientConfiguration;
 
@@ -99,7 +101,7 @@ export class Storage {
 
     if (body !== undefined) {
       const response = await this.s3.putObject({ Body: body, Bucket: bucket, Key: path }).promise();
-      logger.debug(`[STORAGE] S3 file successfully uploaded with Etag: ${response.ETag} and URI: ${uri}`);
+      logger.debug(`S3 file successfully uploaded with Etag: ${response.ETag} and URI: ${uri}`);
     } else if (stream !== undefined) {
       const uploadOptions: S3.PutObjectRequest = { Body: stream, Bucket: bucket, Key: path };
 
@@ -108,7 +110,7 @@ export class Storage {
       }
 
       const response = await this.s3.upload(uploadOptions).promise();
-      logger.debug(`[STORAGE] S3 file successfully streamed with Etag: ${response.ETag} and URI: ${uri}`);
+      logger.debug(`S3 file successfully streamed with Etag: ${response.ETag} and URI: ${uri}`);
     } else {
       throw new Error('Either body or stream options must be set.');
     }
@@ -122,7 +124,7 @@ export class Storage {
   async streamFile(options: StorageReadOptions): Promise<Readable> {
     const { bucket, path, uri } = Storage.normalizeUriOptions(options);
 
-    logger.debug(`[STORAGE] Streaming from ${uri}`);
+    logger.debug(`Streaming from ${uri}`);
     const response = this.s3.getObject({ Bucket: bucket, Key: path }).createReadStream();
 
     return response;
@@ -134,7 +136,7 @@ export class Storage {
   async exists(options: StorageReadOptions): Promise<boolean> {
     const { bucket, path, uri } = Storage.normalizeUriOptions(options);
 
-    logger.debug(`[STORAGE] Checking existance of ${uri}`);
+    logger.debug(`Checking existance of ${uri}`);
     try {
       await this.s3.headObject({ Bucket: bucket, Key: path }).promise();
       return true;

--- a/packages/slackbot/env/.env
+++ b/packages/slackbot/env/.env
@@ -1,7 +1,7 @@
 # Logging
-LOG_REQUESTS=true
+LOG_REQUESTS=false
 LOG_LEVEL=info
-LOG_FORMAT=default
+LOG_FORMAT=pretty
 LOG_TIMESTAMPS=true
 
 # Server

--- a/packages/slackbot/env/.env.development
+++ b/packages/slackbot/env/.env.development
@@ -1,5 +1,5 @@
 # Logging
-LOG_LEVEL=silly
+LOG_LEVEL=trace
 
 # Slack
 SLACK_DEVELOPER_MODE=true

--- a/packages/slackbot/env/.env.test
+++ b/packages/slackbot/env/.env.test
@@ -1,2 +1,2 @@
 # Logging
-LOG_LEVEL=silly
+LOG_LEVEL=debug

--- a/packages/slackbot/package.json
+++ b/packages/slackbot/package.json
@@ -28,7 +28,6 @@
     "dotenv-flow": "3.2.0",
     "express": "4.17.3",
     "module-alias": "2.2.2",
-    "morgan": "1.10.0",
     "reflect-metadata": "0.1.13",
     "tmp-promise": "3.0.3"
   },
@@ -37,7 +36,6 @@
     "@types/express": "4.17.13",
     "@types/jest": "27.4.1",
     "@types/module-alias": "2.0.1",
-    "@types/morgan": "1.9.3",
     "@types/node": "16.11.26",
     "@types/tmp": "0.2.3",
     "@typescript-eslint/eslint-plugin": "5.19.0",

--- a/packages/slackbot/src/app.ts
+++ b/packages/slackbot/src/app.ts
@@ -15,11 +15,13 @@
  */
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import type { LinkUnfurls } from '@slack/bolt';
 import { App, LogLevel } from '@slack/bolt';
 
 import { getUnfurl } from './lib/unfurls';
+
+const logger = getLogger('app');
 
 const app = new App({
   appToken: process.env.SLACK_APP_TOKEN,

--- a/packages/slackbot/src/index.ts
+++ b/packages/slackbot/src/index.ts
@@ -32,7 +32,9 @@ import './environment';
 
 import { startApp } from './app';
 import { startHttpServer } from './server';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
+
+const logger = getLogger('index');
 
 // Safeguard to prevent the application from crashing.
 process.on('uncaughtException', (uncaughtException) => {

--- a/packages/slackbot/src/lib/iex.ts
+++ b/packages/slackbot/src/lib/iex.ts
@@ -18,7 +18,9 @@ import type { ClientOptions } from '@elastic/elasticsearch';
 import { Client } from '@elastic/elasticsearch';
 import type { SearchBody, SearchResponse } from '@iex/models/elasticsearch';
 import type { IndexedInsight } from '@iex/models/indexed/indexed-insight';
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
+
+const logger = getLogger('iex');
 
 const defaultOptions: ClientOptions = {
   node: process.env.ELASTICSEARCH_NODE,

--- a/packages/slackbot/src/lib/unfurls.ts
+++ b/packages/slackbot/src/lib/unfurls.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import logger from '@iex/shared/logger';
+import { getLogger } from '@iex/shared/logger';
 import type { MessageAttachment } from '@slack/bolt';
 
 import { getInsight } from './iex';
+
+const logger = getLogger('unfurls');
 
 interface Link {
   domain: string;
@@ -51,7 +53,7 @@ export const unfurlInsight = async (namespace: string, name: string): Promise<Me
   const insight = await getInsight(namespace, name);
 
   if (insight === undefined) {
-    logger.warn(`[UNFURLS] Insight not found: ${namespace}/${name}`);
+    logger.warn(`Insight not found: ${namespace}/${name}`);
     return undefined;
   }
 

--- a/packages/slackbot/src/server.ts
+++ b/packages/slackbot/src/server.ts
@@ -16,10 +16,11 @@
 
 import type { Server } from 'http';
 
-import logger from '@iex/shared/logger';
+import { getLogger, httpLogger } from '@iex/shared/logger';
 import type { Request, Response } from 'express';
 import express from 'express';
-import morgan from 'morgan';
+
+const logger = getLogger('server');
 
 // Init express
 const app = express();
@@ -28,7 +29,7 @@ app.set('port', Number(process.env.PORT || 3000));
 app.set('env', process.env.NODE_ENV);
 
 if (process.env.LOG_REQUESTS === 'true') {
-  app.use(morgan('dev'));
+  app.use(httpLogger());
 }
 
 // Add APIs


### PR DESCRIPTION
Replaces Winston/Morgan loggers with [pino](https://getpino.io/) and [pino-http](https://github.com/pinojs/pino-http).

Environment variable changes:
* The new `LOG_FORMAT` value `pretty` is preferred over `default`, but both values are supported
* `LOG_LEVEL` value `silly` has been replaced with `trace`.  
* The default environment values have been updated