### PR TITLE
fix: Fix misaligned text and icon on User Tag

### DIFF
--- a/packages/frontend/src/components/user-tag/user-tag.tsx
+++ b/packages/frontend/src/components/user-tag/user-tag.tsx
@@ -19,6 +19,7 @@ import {
   Avatar,
   Box,
   Divider,
+  Flex,
   Heading,
   HStack,
   Icon,
@@ -149,16 +150,12 @@ export const UserTag = ({ user, isLoading, permission, placement = 'right', ...t
             }}
             {...tagProps}
           >
-            <HStack justifyContent="space-between" w="full">
-              <Box>
+            <HStack justifyContent="space-between" w="full" alignItems="center">
+              <Flex align="center">
                 <Avatar name={user.displayName} src={user?.avatarUrl} {...avatarProps} />
                 <TagLabel>{user.displayName}</TagLabel>
-              </Box>
-              {permission && (
-                <Box>
-                  <Icon as={iconFactory('crown')} />
-                </Box>
-              )}
+              </Flex>
+              {permission && <Icon as={iconFactory('crown')} />}
             </HStack>
           </Tag>
         </PopoverTrigger>


### PR DESCRIPTION
This PR fixes the alignment from the UserTag component on the user name and admin icon.

![image](https://user-images.githubusercontent.com/1399744/165147458-065b8d27-38a7-4c18-b651-f126b8314b93.png) vs 
![image](https://user-images.githubusercontent.com/1399744/165147620-95f3fdb6-3581-49b3-ad75-5b858f42a9ad.png)

