### PR TITLE
fix: Update `repositoryData` field when syncing Insights

### DIFF
--- a/packages/backend/src/lib/backends/base.sync.ts
+++ b/packages/backend/src/lib/backends/base.sync.ts
@@ -62,7 +62,7 @@ export abstract class BaseSync {
     const index = ElasticIndex.INSIGHTS;
 
     logger.info(`Publishing ${documentType} to Elasticsearch: ${insight.fullName}`);
-    logger.debug(JSON.stringify(insight, null, 2));
+    logger.trace(JSON.stringify(insight, null, 2));
 
     try {
       const result = await defaultElasticsearchClient.index({
@@ -75,7 +75,7 @@ export abstract class BaseSync {
         refresh
       });
 
-      logger.debug(JSON.stringify(result));
+      logger.trace(JSON.stringify(result));
       logger.info(`Successfully published ${documentType}: ${insight.fullName}`);
     } catch (error: any) {
       logger.error(`Error publishing ${documentType} to Elasticsearch`);
@@ -99,7 +99,8 @@ export abstract class BaseSync {
       await existingDbInsight.$query().patch({
         insightName: insight.fullName,
         itemType: insight.itemType,
-        deletedAt: null
+        deletedAt: null,
+        repositoryData
       });
     } else {
       logger.trace('Insight does not exist in database');
@@ -114,7 +115,8 @@ export abstract class BaseSync {
         await existingDbInsight.$query().patch({
           externalId,
           itemType: insight.itemType,
-          deletedAt: null
+          deletedAt: null,
+          repositoryData
         });
       } else {
         logger.trace('Insight does not exist in database');
@@ -125,7 +127,7 @@ export abstract class BaseSync {
             .select('repositoryTypeId')
             .where('repositoryTypeName', repositoryType)
             .first(),
-          repositoryData: repositoryData,
+          repositoryData,
           itemType: insight.itemType
         });
       }

--- a/packages/backend/src/lib/backends/github.sync.ts
+++ b/packages/backend/src/lib/backends/github.sync.ts
@@ -54,7 +54,14 @@ export class GitHubRepositorySync extends BaseSync {
         return null;
       }
 
-      await super.updateDatabase(insightSyncTask, insight);
+      // If the Insight was renamed, this needs to be updated in the database
+      const updatedInsightSyncTask = {
+        ...insightSyncTask,
+        owner: insight.namespace,
+        repo: insight.repository.externalName
+      };
+
+      await super.updateDatabase(updatedInsightSyncTask, insight);
       await super.publishInsight(insight, insightSyncTask.refresh);
     }
 
@@ -256,9 +263,6 @@ export const githubRepositorySync = async (
     if (thumbnail) {
       insight.thumbnailUrl = thumbnail;
     }
-
-    // Done!
-    logger.debug(JSON.stringify(insight, null, 2));
 
     return insight;
   } finally {


### PR DESCRIPTION
The `repositoryData` field contains details needed to trigger a sync for an Insight, but previously this value was not updated, even if the Insight repository was renamed.  This continued to work thanks to GitHub's redirect functionality, but broke the previous Insight detection to avoid re-publishing unmodified files.

This change updates the repositoryData field with every successful sync.