### PR TITLE
feat: Add search syntax guide popovers to search, activities pages

### DIFF
--- a/packages/frontend/src/components/activity-view/activity-view.tsx
+++ b/packages/frontend/src/components/activity-view/activity-view.tsx
@@ -245,18 +245,22 @@ const getActivityParts = (activity: Activity) => {
             <UserTag user={activity.user} mr="0.25rem" />
             <Text as="span">
               {verb}{' '}
-              <Link
-                to={`/${details.comment.insight.itemType}/${details.comment.insight.fullName}`}
-                display="inline-block"
-              >
-                <Text as="span" fontWeight="bold">
-                  {details.comment.insight.name}
-                </Text>
-              </Link>
+              {details?.comment != null ? (
+                <Link
+                  to={`/${details.comment.insight.itemType}/${details.comment.insight.fullName}`}
+                  display="inline-block"
+                >
+                  <Text as="span" fontWeight="bold">
+                    {details.comment.insight.name}
+                  </Text>
+                </Link>
+              ) : (
+                <DeletedBadge />
+              )}
             </Text>
           </Box>
         ),
-        details: <BlockQuote>{details.comment.commentText}</BlockQuote>
+        details: details?.comment && <BlockQuote>{details.comment.commentText}</BlockQuote>
       };
     }
 

--- a/packages/frontend/src/pages/activity-page/components/activity-search-bar/activity-search-bar.tsx
+++ b/packages/frontend/src/pages/activity-page/components/activity-search-bar/activity-search-bar.tsx
@@ -37,6 +37,8 @@ import { activitySlice } from '../../../../store/activity.slice';
 import type { RootState } from '../../../../store/store';
 import { ActivitySearchBox } from '../activity-search-box/activity-search-box';
 
+import { ActivitySearchSyntax } from './activity-search-syntax';
+
 const availableSortFields = [
   { value: 'occurredAt', label: 'Activity Date' },
   { value: 'relevance', label: 'Relevance' }
@@ -85,8 +87,8 @@ export const ActivitySearchBar = (): ReactElement => {
   };
 
   const optionsArray = Object.entries(options || {})
-    .filter(([key, value]) => value === true)
-    .map(([key, value]) => key);
+    .filter(([, value]) => value === true)
+    .map(([key]) => key);
 
   const onOptionsChange = (selectedOptions: string | string[]) => {
     const updatedOptions = { ...options };
@@ -110,6 +112,8 @@ export const ActivitySearchBar = (): ReactElement => {
         onClear={onClear}
         canClear={query.length > 0 || sort !== undefined}
       />
+
+      <ActivitySearchSyntax />
 
       <Menu>
         <Tooltip placement="left" label="Show sort options" aria-label="Show sort options" zIndex="10">

--- a/packages/frontend/src/pages/activity-page/components/activity-search-bar/activity-search-syntax.tsx
+++ b/packages/frontend/src/pages/activity-page/components/activity-search-bar/activity-search-syntax.tsx
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2022 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Box,
+  Code,
+  Heading,
+  HStack,
+  IconButton,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTrigger,
+  Stack,
+  Text,
+  Tooltip,
+  useBreakpointValue,
+  VStack
+} from '@chakra-ui/react';
+
+import { iconFactoryAs } from '../../../../shared/icon-factory';
+
+export const ActivitySearchSyntax = () => {
+  const tooltip = 'Show search syntax guide';
+  return (
+    <Popover placement={useBreakpointValue({ base: 'auto', md: 'start-start' })} isLazy>
+      <PopoverTrigger>
+        <Box>
+          <Tooltip label={tooltip} aria-label={tooltip}>
+            <IconButton variant="ghost" icon={iconFactoryAs('help')} aria-label={tooltip} />
+          </Tooltip>
+        </Box>
+      </PopoverTrigger>
+      <PopoverContent zIndex={9000} {...useBreakpointValue({ base: {}, lg: { width: 'auto', maxWidth: '3xl' } })}>
+        <PopoverArrow />
+        <PopoverCloseButton />
+        <PopoverHeader>
+          <Heading as="h4" size="md">
+            Search Syntax Guide
+          </Heading>
+        </PopoverHeader>
+        <PopoverBody>
+          <Stack direction={{ base: 'column', lg: 'row' }} fontSize="sm">
+            <VStack align="flex-start" flexBasis="50%">
+              <Heading as="h5" size="sm">
+                Syntax
+              </Heading>
+              <Box>
+                <Code>term</Code>
+                <Text>Search for results containing the given term</Text>
+              </Box>
+              <Box>
+                <Code>"search phrase"</Code>
+                <Text>Search for results containing quoted phrase exactly</Text>
+              </Box>
+              <Box>
+                <HStack>
+                  <Code>filter:string</Code>
+                  <Text>/</Text>
+                  <Code>filter:"string"</Code>
+                </HStack>
+                <Text>Match a filter value</Text>
+              </Box>
+              <Box>
+                <HStack>
+                  <Code>filter:{`{string, string, ...}`}</Code>
+                </HStack>
+                <Text>Match one or more filter values</Text>
+              </Box>
+              <Box>
+                <VStack align="flex-start">
+                  <HStack wrap="wrap">
+                    <Code>filter:&lt;value</Code>
+                    <Text>/</Text>
+                    <Code>filter:&lt;=value</Code>
+                  </HStack>
+                  <HStack wrap="wrap">
+                    <Code>filter:&gt;value</Code>
+                    <Text>/</Text>
+                    <Code>filter:&gt;=value</Code>
+                  </HStack>
+                  <HStack wrap="wrap">
+                    <Code>filter:[value to value]</Code>
+                  </HStack>
+                </VStack>
+                <Text>Match a filter to a range value</Text>
+              </Box>
+            </VStack>
+            <VStack align="flex-start" flexBasis="50%">
+              <Heading as="h5" size="sm">
+                Filters
+              </Heading>
+              <Box>
+                <HStack>
+                  <Code>user:username</Code>
+                </HStack>
+                <Text>Activity user</Text>
+              </Box>
+              <Box>
+                <VStack align="flex-start">
+                  <Code>activityType:filter</Code>
+
+                  <Code>activityType:{`{filter, ...}`}</Code>
+                </VStack>
+                <Text>Activity type(s)</Text>
+              </Box>
+              <Box>
+                <Code>insight:insightFullName</Code>
+                <Text>Related Insight</Text>
+              </Box>
+              <Box>
+                <VStack align="flex-start">
+                  <Code>occurredAt:dateFilter</Code>
+                </VStack>
+                <Text>Filter by a single date or range of dates</Text>
+              </Box>
+            </VStack>
+          </Stack>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/packages/frontend/src/pages/search-page/components/search-bar/search-bar.tsx
+++ b/packages/frontend/src/pages/search-page/components/search-bar/search-bar.tsx
@@ -37,6 +37,8 @@ import { searchSlice } from '../../../../store/search.slice';
 import type { RootState } from '../../../../store/store';
 import { SearchBox } from '../search-box/search-box';
 
+import { SearchSyntax } from './search-syntax';
+
 const availableSortFields = [
   { value: 'relevance', label: 'Relevance' },
   { value: 'createdAt', label: 'Created Date' },
@@ -92,8 +94,8 @@ export const SearchBar = (): ReactElement => {
   };
 
   const optionsArray = Object.entries(options || {})
-    .filter(([key, value]) => value === true)
-    .map(([key, value]) => key);
+    .filter(([, value]) => value === true)
+    .map(([key]) => key);
 
   const onOptionsChange = (selectedOptions: string | string[]) => {
     const updatedOptions = { ...options };
@@ -118,6 +120,8 @@ export const SearchBar = (): ReactElement => {
         onClear={onClear}
         canClear={query.length > 0 || sort !== undefined}
       />
+
+      <SearchSyntax />
 
       <Menu>
         <Tooltip placement="left" label="Show sort options" aria-label="Show sort options" zIndex="10">

--- a/packages/frontend/src/pages/search-page/components/search-bar/search-syntax.tsx
+++ b/packages/frontend/src/pages/search-page/components/search-bar/search-syntax.tsx
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2022 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Box,
+  Code,
+  Heading,
+  HStack,
+  IconButton,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTrigger,
+  Stack,
+  Text,
+  Tooltip,
+  useBreakpointValue,
+  VStack
+} from '@chakra-ui/react';
+
+import { iconFactoryAs } from '../../../../shared/icon-factory';
+
+export const SearchSyntax = () => {
+  const tooltip = 'Show search syntax guide';
+  return (
+    <Popover placement={useBreakpointValue({ base: 'auto', md: 'start-start' })} isLazy>
+      <PopoverTrigger>
+        <Box>
+          <Tooltip label={tooltip} aria-label={tooltip}>
+            <IconButton variant="ghost" icon={iconFactoryAs('help')} aria-label={tooltip} />
+          </Tooltip>
+        </Box>
+      </PopoverTrigger>
+      <PopoverContent zIndex={9000} {...useBreakpointValue({ base: {}, lg: { width: 'auto', maxWidth: '3xl' } })}>
+        <PopoverArrow />
+        <PopoverCloseButton />
+        <PopoverHeader>
+          <Heading as="h4" size="md">
+            Search Syntax Guide
+          </Heading>
+        </PopoverHeader>
+        <PopoverBody>
+          <Stack direction={{ base: 'column', lg: 'row' }} fontSize="sm">
+            <VStack align="flex-start" flexBasis="50%">
+              <Heading as="h5" size="sm">
+                Syntax
+              </Heading>
+              <Box>
+                <Code>term</Code>
+                <Text>Search for results containing the given term</Text>
+              </Box>
+              <Box>
+                <Code>"search phrase"</Code>
+                <Text>Search for results containing quoted phrase exactly</Text>
+              </Box>
+              <Box>
+                <HStack>
+                  <Code>filter:string</Code>
+                  <Text>/</Text>
+                  <Code>filter:"string"</Code>
+                </HStack>
+                <Text>Match a filter value</Text>
+              </Box>
+              <Box>
+                <HStack>
+                  <Code>filter:{`{string, string, ...}`}</Code>
+                </HStack>
+                <Text>Match one or more filter values</Text>
+              </Box>
+              <Box>
+                <VStack align="flex-start">
+                  <HStack wrap="wrap">
+                    <Code>filter:&lt;value</Code>
+                    <Text>/</Text>
+                    <Code>filter:&lt;=value</Code>
+                  </HStack>
+                  <HStack wrap="wrap">
+                    <Code>filter:&gt;value</Code>
+                    <Text>/</Text>
+                    <Code>filter:&gt;=value</Code>
+                  </HStack>
+                  <HStack wrap="wrap">
+                    <Code>filter:[value to value]</Code>
+                  </HStack>
+                </VStack>
+                <Text>Match a filter to a range value</Text>
+              </Box>
+            </VStack>
+            <VStack align="flex-start" flexBasis="50%">
+              <Heading as="h5" size="sm">
+                Filters
+              </Heading>
+              <Box>
+                <HStack>
+                  <Code>author:username</Code>
+                  <Text>/</Text>
+                  <Code>@username</Code>
+                </HStack>
+                <Text>Insight author</Text>
+              </Box>
+              <Box>
+                <HStack>
+                  <Code>tag:tag</Code>
+                  <Text>/</Text>
+                  <Code>#tag</Code>
+                </HStack>
+                <Text>Insight tag</Text>
+              </Box>
+              <Box>
+                <HStack>
+                  <Code>team:team</Code>
+                  <Text>/</Text>
+                  <Code>team:"Team Name"</Code>
+                </HStack>
+                <Text>Insight team</Text>
+              </Box>
+              <Box>
+                <Code>itemType:{`{insight, page}`}</Code>
+                <Text>Result type (Insight, Page, Template)</Text>
+              </Box>
+              <Box>
+                <VStack align="flex-start">
+                  <Code>createdDate:dateFilter</Code>
+                  <Code>updatedDate:dateFilter</Code>
+                  <Code>publishedDate:dateFilter</Code>
+                </VStack>
+                <Text>Filter by a single date or range of dates</Text>
+              </Box>
+            </VStack>
+          </Stack>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/packages/frontend/src/pages/search-page/components/search-box/search-box.tsx
+++ b/packages/frontend/src/pages/search-page/components/search-box/search-box.tsx
@@ -39,6 +39,7 @@ export const SearchBox = ({ query, canClear, onQueryChange, onClear }: Props): R
         onChange={(e) => onQueryChange(e.target.value)}
         aria-label="Search"
       />
+
       {canClear && (
         <InputRightElement zIndex="unset">
           <Tooltip placement="left" label="Clear search" aria-label="Clear search">

--- a/packages/frontend/src/pages/search-page/search-page.tsx
+++ b/packages/frontend/src/pages/search-page/search-page.tsx
@@ -48,7 +48,7 @@ export const SearchPage = () => {
     paused: !initialized.current
   });
 
-  const insightResults = data.insights.results.map(({ score, insight }) => {
+  const insightResults = data.insights.results.map(({ insight }) => {
     return { id: insight.id, name: insight.name, fullName: insight.fullName, itemType: insight.itemType };
   });
 


### PR DESCRIPTION
Adds popovers to the Insight Search and Activity Search bar, detailing the search syntax.


![Screen Shot 2022-05-05 at 11 09 36 AM](https://user-images.githubusercontent.com/3084806/166954497-4f369da9-3e4f-44fa-a4ef-179a28727ef5.png)