### PR TITLE
fix: Add option to delete Insight from IEX but keep GH repository

### DIFF
--- a/packages/backend/schema.gql
+++ b/packages/backend/schema.gql
@@ -337,7 +337,7 @@ type Mutation {
   cloneInsight(insightId: ID!): Draft!
   deleteComment(commentId: ID!): Comment!
   deleteDraft(draftKey: String!): Draft!
-  deleteInsight(insightId: ID!): ID!
+  deleteInsight(archiveRepo: Boolean!, insightId: ID!): ID!
   deleteNews(newsId: ID!): News!
   getAccessToken(code: String!): String!
   likeActivity(activityId: ID!, liked: Boolean!): Activity!

--- a/packages/backend/src/resolvers/insight.resolver.ts
+++ b/packages/backend/src/resolvers/insight.resolver.ts
@@ -442,14 +442,18 @@ export class InsightResolver {
 
   @Authorized<Permission>({ user: true, github: true })
   @Mutation(() => ID)
-  async deleteInsight(@Arg('insightId', () => ID) insightId: string, @Ctx() ctx: Context): Promise<string> {
+  async deleteInsight(
+    @Arg('insightId', () => ID) insightId: string,
+    @Arg('archiveRepo') archiveRepo: boolean,
+    @Ctx() ctx: Context
+  ): Promise<string> {
     logger.debug('Deleting Insight', insightId);
 
     try {
       const [, dbInsightId] = fromGlobalId(insightId);
 
       // Delete Insight
-      await this.insightService.deleteInsight(dbInsightId, ctx.user!);
+      await this.insightService.deleteInsight(dbInsightId, archiveRepo, ctx.user!);
 
       return insightId;
     } catch (error: any) {

--- a/packages/backend/src/services/insight.service.ts
+++ b/packages/backend/src/services/insight.service.ts
@@ -630,7 +630,7 @@ export class InsightService {
    * @param user User making the change
    * @param hard True for a hard delete, false for a soft delete (default)
    */
-  async deleteInsight(insightId: number, user: User, hard = false): Promise<DbInsight> {
+  async deleteInsight(insightId: number, archiveRepo: boolean, user: User, hard = false): Promise<DbInsight> {
     if (hard === true) {
       throw new Error('Hard deletes of Insights are not yet supported.');
     }
@@ -644,7 +644,7 @@ export class InsightService {
     const insight = await getInsight(insightId);
     const isMissing = await this.isRepositoryMissing(insight!.repository);
 
-    if (!isMissing) {
+    if (!isMissing && archiveRepo) {
       // Archive GitHub repository
       await archiveRepository(user.githubPersonalAccessToken!, existingInsight.externalId);
     }

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/action-bar/action-bar.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/action-bar/action-bar.tsx
@@ -58,7 +58,7 @@ interface Props {
   nextInsight?: Pick<Insight, 'id' | 'name' | 'fullName' | 'itemType'>;
   previousInsight?: Pick<Insight, 'id' | 'name' | 'fullName' | 'itemType'>;
   onClone: () => Promise<boolean>;
-  onDelete: () => Promise<boolean>;
+  onDelete: (archiveRepo: boolean) => Promise<boolean>;
   onFetchLikedBy: (insightId?: string) => Promise<User[]>;
   onLike: (liked: boolean) => Promise<boolean>;
 }

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/delete-dialog/delete-dialog.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/delete-dialog/delete-dialog.tsx
@@ -38,7 +38,7 @@ import { iconFactory } from '../../../../../../shared/icon-factory';
 interface Props {
   insight: Insight;
   isOpen: boolean;
-  onDelete: () => Promise<boolean>;
+  onDelete: (archiveRepo: boolean) => Promise<boolean>;
   onClose: () => void;
 }
 
@@ -47,9 +47,9 @@ export const DeleteDialog = ({ insight, isOpen, onDelete, onClose }: Props) => {
   const [isDeleting, setDeleting] = useState(false);
   const navigate = useNavigate();
 
-  const onDeleteInternal = async () => {
+  const onDeleteInternal = async (archiveRepo) => {
     setDeleting(true);
-    const deleted = await onDelete();
+    const deleted = await onDelete(archiveRepo);
     if (deleted) {
       navigate('/');
     } else {
@@ -73,8 +73,12 @@ export const DeleteDialog = ({ insight, isOpen, onDelete, onClose }: Props) => {
                 accessible.
               </Text>
               <Text>
-                The GitHub repository for the {titleize(insight.itemType)} will be archived rather than deleted. This
-                will make it read-only on GitHub, and it can be manually recovered later if necessary.
+                Based on your choice the Githu repository for this {titleize(insight.itemType)} can be either archived
+                or left untouched after the Insight is deleted.
+              </Text>
+              <Text>
+                If you click 'Delete' the Github repository will be archived, else if you click 'Delete, but keep repo'
+                the Github repository will be left untouched.
               </Text>
             </VStack>
           </AlertDialogBody>
@@ -82,8 +86,11 @@ export const DeleteDialog = ({ insight, isOpen, onDelete, onClose }: Props) => {
             <Button ref={cancelRef} onClick={onClose}>
               Cancel
             </Button>
-            <Button colorScheme="red" onClick={onDeleteInternal} ml={3} isLoading={isDeleting}>
+            <Button colorScheme="red" onClick={() => onDeleteInternal(true)} ml={3} isLoading={isDeleting}>
               Delete
+            </Button>
+            <Button colorScheme="red" onClick={() => onDeleteInternal(false)} ml={3} isLoading={isDeleting}>
+              Delete, but keep repo
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-header/insight-header.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-header/insight-header.tsx
@@ -27,7 +27,7 @@ interface Props {
   nextInsight?: Pick<Insight, 'id' | 'name' | 'fullName' | 'itemType'>;
   previousInsight?: Pick<Insight, 'id' | 'name' | 'fullName' | 'itemType'>;
   onClone: () => Promise<boolean>;
-  onDelete: () => Promise<boolean>;
+  onDelete: (archiveRepo: boolean) => Promise<boolean>;
   onFetchLikedBy: (insightId?: string) => Promise<User[]>;
   onLike: (liked: boolean) => Promise<boolean>;
 }

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/page-header/page-header.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/page-header/page-header.tsx
@@ -29,7 +29,7 @@ interface Props {
   nextInsight?: Pick<Insight, 'id' | 'name' | 'fullName' | 'itemType'>;
   previousInsight?: Pick<Insight, 'id' | 'name' | 'fullName' | 'itemType'>;
   onClone: () => Promise<boolean>;
-  onDelete: () => Promise<boolean>;
+  onDelete: (archiveRepo: boolean) => Promise<boolean>;
   onFetchLikedBy: (insightId?: string) => Promise<User[]>;
   onLike: (liked: boolean) => Promise<boolean>;
 }

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/item-type-viewer.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/item-type-viewer.tsx
@@ -25,7 +25,7 @@ export interface ItemTypeViewerProps {
   nextInsight?: Pick<Insight, 'id' | 'name' | 'fullName' | 'itemType'>;
   previousInsight?: Pick<Insight, 'id' | 'name' | 'fullName' | 'itemType'>;
   onClone: () => Promise<boolean>;
-  onDelete: () => Promise<boolean>;
+  onDelete: (archiveRepo: boolean) => Promise<boolean>;
   onFetchLikedBy: (insightId?: string) => Promise<User[]>;
   onLike: (liked: boolean) => Promise<boolean>;
 }

--- a/packages/frontend/src/pages/insight-page/insight-page.tsx
+++ b/packages/frontend/src/pages/insight-page/insight-page.tsx
@@ -87,9 +87,10 @@ export const InsightPage = ({ isExport = false }) => {
     return true;
   };
 
-  const onDelete = async (): Promise<boolean> => {
+  const onDelete = async (archiveRepo): Promise<boolean> => {
     const { error } = await deleteInsight({
-      insightId: insight.id
+      insightId: insight.id,
+      archiveRepo: archiveRepo
     });
 
     if (error) {

--- a/packages/frontend/src/shared/useInsight.ts
+++ b/packages/frontend/src/shared/useInsight.ts
@@ -117,8 +117,8 @@ const INSIGHT_QUERY = gql`
 `;
 
 const INSIGHT_DELETE_MUTATION = gql`
-  mutation InsightDelete($insightId: ID!) {
-    deleteInsight(insightId: $insightId)
+  mutation InsightDelete($insightId: ID!, $archiveRepo: Boolean!) {
+    deleteInsight(insightId: $insightId, archiveRepo: $archiveRepo)
   }
 `;
 


### PR DESCRIPTION
This PR addresses adding an extra option when deleting an Insight to delete and keep the GH repository untouched or delete the Insight and archived the GH repository.

![image](https://user-images.githubusercontent.com/1399744/167198105-4dbd5078-de05-4075-b7ef-e515dae855b7.png)
