### PR TITLE
feat: Autocomplete file names in the Markdown editor

### DIFF
--- a/packages/frontend/src/components/markdown-split-editor/markdown-split-editor.tsx
+++ b/packages/frontend/src/components/markdown-split-editor/markdown-split-editor.tsx
@@ -117,6 +117,7 @@ interface Props {
   baseAssetUrl?: string;
   baseLinkUrl?: string;
   contents: string;
+  getAutocompleteFiles?: () => string[];
   onChange: (updatedContents: string) => void;
   showFormattingHelp?: boolean;
   showPreview?: boolean;
@@ -128,6 +129,7 @@ export const MarkdownSplitEditor = ({
   baseAssetUrl,
   baseLinkUrl,
   contents,
+  getAutocompleteFiles,
   onChange,
   showFormattingHelp = true,
   showPreview = true,
@@ -217,6 +219,7 @@ export const MarkdownSplitEditor = ({
         >
           <MarkdownEditor
             contents={contents}
+            getAutocompleteFiles={getAutocompleteFiles}
             onContentsChange={setInternalValue}
             uploadFile={uploadFile}
             scrollSync={scrollSync}

--- a/packages/frontend/src/pages/insight-editor/components/insight-file-editor/insight-file-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/components/insight-file-editor/insight-file-editor.tsx
@@ -17,6 +17,7 @@
 import type { FlexProps } from '@chakra-ui/react';
 import { Flex, Spinner } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
+import type { UseFormReturn } from 'react-hook-form';
 
 import { Alert } from '../../../../components/alert/alert';
 import { CodeEditor } from '../../../../components/code-editor/code-editor';
@@ -33,6 +34,7 @@ import {
   MIME_EDITOR
 } from '../../../../shared/mime-utils';
 import { useFetch } from '../../../../shared/useFetch';
+import type { DraftForm } from '../../draft-form';
 
 const preferredMimeTypes = {
   'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'application/pdf',
@@ -91,6 +93,7 @@ interface Props {
   baseAssetUrl?: string;
   baseLinkUrl?: string;
   file: InsightFile;
+  form: UseFormReturn<DraftForm>;
   onFileChange: (updatedFile: InsightFileInput) => void;
   insight: Insight;
   transformAssetUri: (uri: string) => string;
@@ -101,6 +104,7 @@ export const InsightFileEditor = ({
   baseAssetUrl = '/',
   baseLinkUrl = '/',
   file,
+  form,
   onFileChange,
   insight,
   transformAssetUri,
@@ -143,6 +147,7 @@ export const InsightFileEditor = ({
           renderer={(contents) => (
             <MarkdownSplitEditor
               contents={contents}
+              getAutocompleteFiles={() => form.getValues('files')?.map((f) => f.path) ?? []}
               onChange={onContentsChanged}
               baseAssetUrl={baseAssetUrl}
               baseLinkUrl={baseLinkUrl}

--- a/packages/frontend/src/pages/insight-editor/insight-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-editor.tsx
@@ -418,6 +418,7 @@ export const InsightEditor = memo(
                   <InsightFileEditor
                     key={selectedFileId}
                     insight={insight}
+                    form={form}
                     file={selectedFile}
                     onFileChange={fileChange}
                     baseAssetUrl={`/api/v1/insights/${insight.fullName}/assets`}
@@ -428,16 +429,6 @@ export const InsightEditor = memo(
                     overflow="auto"
                   />
                 )}
-                {/* <MarkdownSplitEditor
-                name="readme.contents"
-                contents={updatedReadme}
-                form={form}
-                flexGrow={1}
-                overflow="auto"
-                baseAssetUrl={`/api/v1/insights/${insight.fullName}/assets`}
-                baseLinkUrl={`/${itemType}/${insight.fullName}/files`}
-                transformAssetUri={transformAssetUri}
-              /> */}
               </TabPanel>
             </TabPanels>
           </Tabs>


### PR DESCRIPTION
This change adds file name autocomplete to the Markdown editor, triggered by an open parenthesis `(`.

This is designed to work specifically with `![](` (images) and `[link](` (links)