### PR TITLE
feat: Create Drafts and apply Templates in Backend

### DIFF
--- a/packages/backend/schema.gql
+++ b/packages/backend/schema.gql
@@ -356,6 +356,7 @@ type Mutation {
   addCollaborator(insightId: ID!, permission: String, userId: ID!): Insight!
   addComment(comment: CommentInput!): Comment!
   addNews(news: NewsInput!): News!
+  applyTemplateToDraft(draftKey: String!, templateId: ID!): Draft!
   cloneInsight(insightId: ID!): Draft!
   createDraft(draftKey: String, itemType: String!): Draft!
   deleteComment(commentId: ID!): Comment!

--- a/packages/backend/schema.gql
+++ b/packages/backend/schema.gql
@@ -357,6 +357,7 @@ type Mutation {
   addComment(comment: CommentInput!): Comment!
   addNews(news: NewsInput!): News!
   cloneInsight(insightId: ID!): Draft!
+  createDraft(draftKey: String, itemType: String!): Draft!
   deleteComment(commentId: ID!): Comment!
   deleteDraft(draftKey: String!): Draft!
   deleteInsight(archiveRepo: Boolean!, insightId: ID!): ID!

--- a/packages/backend/src/lib/import.ts
+++ b/packages/backend/src/lib/import.ts
@@ -26,6 +26,7 @@ import * as turndownPluginGfm from 'turndown-plugin-gfm';
 import { DraftDataInput, DraftKey } from '../models/draft';
 import { AttachmentService } from '../services/attachment.service';
 import { DraftService } from '../services/draft.service';
+import { TemplateService } from '../services/template.service';
 
 const logger = getLogger('import');
 
@@ -190,7 +191,7 @@ export function convertToDraft(request: ImportRequest): DraftDataInput {
 export async function importToNewDraft(request: ImportRequest): Promise<DraftKey> {
   logger.info(`Importing web page ${request.url}`);
 
-  const draftService = new DraftService(new AttachmentService());
+  const draftService = new DraftService(new AttachmentService(), new TemplateService());
   const draftKey = draftService.newDraftKey();
 
   const draftData = convertToDraft(request);

--- a/packages/backend/src/resolvers/attachment.resolver.ts
+++ b/packages/backend/src/resolvers/attachment.resolver.ts
@@ -23,6 +23,7 @@ import { Arg, Authorized, Ctx, Mutation, Resolver } from 'type-graphql';
 import { Service } from 'typedi';
 
 import { Context } from '../models/context';
+import { DraftKey } from '../models/draft';
 import { InsightFile, InsightFileUploadInput } from '../models/insight-file';
 import { Permission } from '../models/permission';
 import { AvatarUploadResult } from '../models/user';
@@ -41,7 +42,7 @@ export class AttachmentResolver {
   @Authorized<Permission>({ user: true })
   @Mutation(() => InsightFile)
   async uploadSingleFile(
-    @Arg('draftKey') draftKey: string,
+    @Arg('draftKey') draftKey: DraftKey,
     @Arg('attachment') attachment: InsightFileUploadInput,
     @Arg('file', () => GraphQLUpload) file: FileUpload
   ): Promise<InsightFile> {

--- a/packages/backend/src/resolvers/draft.resolver.ts
+++ b/packages/backend/src/resolvers/draft.resolver.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { ItemType } from '@iex/models/item-type';
 import { getLogger } from '@iex/shared/logger';
 import { Arg, Authorized, Ctx, FieldResolver, ID, Mutation, Query, Resolver, Root } from 'type-graphql';
 import { Service } from 'typedi';
@@ -123,6 +124,24 @@ export class DraftResolver {
 
     try {
       return await this.draftService.deleteDraft(draftKey, ctx.user!);
+    } catch (error: any) {
+      logger.error(error.message);
+      logger.error(JSON.stringify(error, null, 2));
+      throw error;
+    }
+  }
+
+  @Authorized<Permission>({ user: true, github: true })
+  @Mutation(() => Draft)
+  async createDraft(
+    @Arg('itemType') itemType: ItemType,
+    @Arg('draftKey', { nullable: true }) draftKey: DraftKey,
+    @Ctx() ctx: Context
+  ): Promise<Draft> {
+    logger.debug('Creating a new Draft');
+
+    try {
+      return await this.draftService.createDraft(ctx.user!, draftKey, itemType);
     } catch (error: any) {
       logger.error(error.message);
       logger.error(JSON.stringify(error, null, 2));

--- a/packages/backend/src/resolvers/insight.resolver.ts
+++ b/packages/backend/src/resolvers/insight.resolver.ts
@@ -28,6 +28,7 @@ import { getInsight } from '../lib/elasticsearch';
 import { Activity, ActivityType, IndexedActivityDetails } from '../models/activity';
 import { CommentConnection } from '../models/comment';
 import { Context } from '../models/context';
+import { DraftKey } from '../models/draft';
 import { Insight, DbInsight, ValidateInsightName, InsightChangeConnection } from '../models/insight';
 import { Permission } from '../models/permission';
 import { Repository } from '../models/repository';
@@ -310,7 +311,7 @@ export class InsightResolver {
 
   @Authorized<Permission>({ user: true, github: true })
   @Mutation(() => Insight)
-  async publishDraft(@Arg('draftKey') draftKey: string, @Ctx() ctx: Context): Promise<Insight> {
+  async publishDraft(@Arg('draftKey') draftKey: DraftKey, @Ctx() ctx: Context): Promise<Insight> {
     logger.debug('Publishing Draft Key', draftKey);
 
     try {

--- a/packages/backend/src/services/draft.service.ts
+++ b/packages/backend/src/services/draft.service.ts
@@ -170,13 +170,18 @@ export class DraftService {
       }
     };
 
-    const upserted = await this.upsertDraft(draft, user);
+    if (user.defaultTemplate) {
+      // Apply user's default template to the draft initially
+      return this.applyTemplateToDraft(draft, user.defaultTemplate, user);
+    } else {
+      const upserted = await this.upsertDraft(draft, user);
 
-    if (upserted.updatedAt == null) {
-      upserted.updatedAt = new Date();
+      if (upserted.updatedAt == null) {
+        upserted.updatedAt = new Date();
+      }
+
+      return upserted;
     }
-
-    return upserted;
   }
 
   /**

--- a/packages/backend/test/lib/import.test-disabled.ts
+++ b/packages/backend/test/lib/import.test-disabled.ts
@@ -16,6 +16,9 @@
 
 import { convertToDraft, ImportRequest } from '../../src/lib/import';
 
+// Disabled these tests since they cause `elasticsearch.ts` to load and attempt initialization
+// Need to refactor `elasticsearch.ts` to avoid initializing a Client on load
+
 describe('import', () => {
   describe('convertToMarkdown', () => {
     test('Simple HTML', () => {

--- a/packages/frontend/src/pages/insight-editor/insight-draft-container.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-draft-container.tsx
@@ -84,13 +84,21 @@ const UPLOAD_SINGLE_FILE_MUTATION = gql`
   }
 `;
 
+interface Props {
+  insight: Insight;
+  draft: DraftDataInput;
+  draftKey: string;
+  onApplyTemplate: (templateId: string) => Promise<void>;
+  onRefresh: () => void;
+}
+
 /**
  * This component is rendered only after the following are available:
  *   - Insight
  *   - DraftKey
  *   - Draft (defaults to an empty object)
  */
-export const InsightDraftContainer = ({ insight, draft, draftKey, onRefresh }) => {
+export const InsightDraftContainer = ({ insight, draft, draftKey, onApplyTemplate, onRefresh }: Props) => {
   const toast = useToast();
 
   // Store copy of last saved draft for comparisons
@@ -217,6 +225,7 @@ export const InsightDraftContainer = ({ insight, draft, draftKey, onRefresh }) =
         publish={publish}
         isSavingDraft={isSavingDraft}
         isPublishing={isPublishing}
+        onApplyTemplate={onApplyTemplate}
         onRefresh={onRefresh}
         uploadFile={uploadFile}
       />

--- a/packages/frontend/src/pages/insight-editor/insight-draft-switcher.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-draft-switcher.tsx
@@ -42,9 +42,9 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { gql, useMutation, useQuery } from 'urql';
 
 import { Link as RouterLink } from '../../components/link/link';
-import type { Insight } from '../../models/generated/graphql';
 import { formatRelativeIntl } from '../../shared/date-utils';
 import { iconFactory, iconFactoryAs } from '../../shared/icon-factory';
+import { ItemType } from '../../shared/item-type';
 import type { RootState } from '../../store/store';
 import { UserHealthCheck } from '../main-page/components/user-health-check/user-health-check';
 
@@ -94,7 +94,7 @@ const DELETE_DRAFT_MUTATION = gql`
 export const InsightDraftSwitcher = ({ insight, onRefresh }) => {
   const toast = useToast();
   const location = useLocation();
-  const state: { clonedFrom?: Insight; itemType?: string } | null = location.state as any;
+  const state: { itemType?: ItemType } | null = location.state as any;
 
   const navigate = useNavigate();
   const { '*': draftKey } = useParams();
@@ -154,14 +154,7 @@ export const InsightDraftSwitcher = ({ insight, onRefresh }) => {
   };
 
   useEffect(() => {
-    // If cloning, just create a new draft immediately
-    // Can't clone onto an existing draft
-    if (state?.clonedFrom != null && draftKey === '') {
-      createNewDraft();
-      return;
-    }
-
-    // Otherwise, wait for pending drafts to load
+    // Wait for pending drafts to load
     if (pendingDraftsData === undefined) {
       return;
     }
@@ -276,8 +269,7 @@ export const InsightDraftSwitcher = ({ insight, onRefresh }) => {
         <InsightDraftEditor
           insight={insight}
           draftKey={draftKey}
-          clonedFrom={state?.clonedFrom}
-          itemType={state?.itemType}
+          itemType={state?.itemType ?? ItemType.INSIGHT}
           onRefresh={onRefresh}
         />
       )}

--- a/packages/frontend/src/pages/insight-editor/insight-editor.tsx
+++ b/packages/frontend/src/pages/insight-editor/insight-editor.tsx
@@ -101,10 +101,7 @@ export const InsightEditor = memo(
     const navigate = useNavigate();
     const toast = useToast();
 
-    const { userInfo } = useSelector((state: RootState) => state.user);
-
     const ignoreDirtyCheck = useRef(false);
-    const initDefaultTemplate = useRef(false);
 
     const [isApplyingTemplate, setApplyingTemplate] = useState(false);
 
@@ -112,7 +109,6 @@ export const InsightEditor = memo(
     const color = useColorModeValue('gray.700', 'gray.200');
 
     const isNewInsight = insight.id === undefined;
-    const isCloned = insight.creation?.clonedFrom != null;
 
     const readmeFile = insight.files?.find((f) => f.path === 'README.md');
 
@@ -224,27 +220,6 @@ export const InsightEditor = memo(
       },
       [onApplyTemplate]
     );
-
-    useEffect(() => {
-      // TODO: Do this in the backend
-      const f = async () => {
-        if (
-          !initDefaultTemplate.current &&
-          isNewInsight &&
-          !isCloned &&
-          templatesData &&
-          userInfo?.defaultTemplateId &&
-          !form.getValues('initializedTemplate')
-        ) {
-          const defaultTemplate = templatesData.templates.find(
-            (template) => template.id === userInfo.defaultTemplateId
-          );
-          initDefaultTemplate.current = true;
-          await templateChange(defaultTemplate);
-        }
-      };
-      f();
-    }, [form, isCloned, isNewInsight, templateChange, templatesData, userInfo]);
 
     const fileTreeChange = (updatedTree: InsightFileTree): void => {
       setFileTree(updatedTree);


### PR DESCRIPTION
This change contains several commits that migrate the process of creating new Drafts and applying Templates to the backend.  Previously, using a template was a very shallow process whereby the `README.md` contents were copied into the draft via the frontend.  This was limiting in that it didn't allow any additional files to be included in a template.

To address this, the following changes were made:
1. New drafts are created on the backend via a GraphQL mutation.  If the editor loads a new Draft Key that doesn't exist, it triggers a mutation to create the draft and loads it
2. If the user manually changes the template in the Insight Editor, it triggers a GraphQL mutation that applies the draft to the template.  This is similar to the Insight Clone functionality, as it now copies all the files from the template over to the draft.
3. If the user has a default template configured, it will be applied to the new draft during the creation process, using the same method as the previous step.

Functionally, this allows additional files to be included in Templates and used to create new Insights, and simplified the Insight Editor somewhat by moving all logic about default templates or changing templates to the backend.