### PR TITLE
fix: Fix editing Insight issue caused by server-side drafts

### DIFF
--- a/packages/frontend/src/components/renderers/table-renderer/table-renderer.tsx
+++ b/packages/frontend/src/components/renderers/table-renderer/table-renderer.tsx
@@ -93,7 +93,6 @@ export const TableRenderer = ({ columns, data }) => {
               return (
                 <Tr {...row.getRowProps()}>
                   {row.cells.map((cell) => {
-                    console.log('cell', cell);
                     return <Td {...cell.getCellProps()}>{cell.render('Cell')}</Td>;
                   })}
                 </Tr>


### PR DESCRIPTION
The recent changes to create new Insight drafts server-side broke the ability to edit an Insight, since there's no logic to initialize a draft from an existing Insight. This fixes the issue by allowing the client-side to create a blank draft and extend it with the contents of the Insight.
