### PR TITLE
feat: Add Insight search sort options for view/like/comment count

### DIFF
--- a/packages/backend/indices/iex-insights.json
+++ b/packages/backend/indices/iex-insights.json
@@ -1,6 +1,9 @@
 {
   "mappings": {
     "properties": {
+      "commentCount": {
+        "type": "integer"
+      },
       "contributors": {
         "properties": {
           "userName": {
@@ -44,9 +47,6 @@
           }
         }
       },
-      "forks": {
-        "type": "integer"
-      },
       "fullName": {
         "type": "text",
         "fields": {
@@ -63,11 +63,8 @@
       "itemType": {
         "type": "keyword"
       },
-      "syncedAt": {
-        "type": "date"
-      },
-      "updatedAt": {
-        "type": "date"
+      "likeCount": {
+        "type": "integer"
       },
       "metadata": {
         "properties": {
@@ -155,6 +152,9 @@
               }
             }
           },
+          "forks": {
+            "type": "integer"
+          },
           "isArchived": {
             "type": "boolean"
           },
@@ -190,6 +190,9 @@
               }
             }
           },
+          "stars": {
+            "type": "integer"
+          },
           "type": {
             "type": "keyword"
           },
@@ -204,8 +207,8 @@
           }
         }
       },
-      "stars": {
-        "type": "integer"
+      "syncedAt": {
+        "type": "date"
       },
       "tags": {
         "type": "text",
@@ -216,6 +219,12 @@
             "normalizer": "lowercase_normalizer"
           }
         }
+      },
+      "updatedAt": {
+        "type": "date"
+      },
+      "viewCount": {
+        "type": "integer"
       }
     }
   },

--- a/packages/backend/schema.gql
+++ b/packages/backend/schema.gql
@@ -176,7 +176,6 @@ type Insight {
   creation: InsightCreation
   description: String!
   files: [InsightFile!]
-  forks: Float!
   fullName: String!
   id: ID!
   itemType: String!
@@ -188,7 +187,6 @@ type Insight {
   namespace: String!
   readme: InsightReadme
   repository: Repository!
-  stars: Float!
   syncedAt: String!
   tags: [String!]!
   thumbnailUrl: String
@@ -475,10 +473,12 @@ type Repository {
   externalFullName: String!
   externalId: String!
   externalName: String!
+  forks: Float!
   isArchived: Boolean!
   isMissing: Boolean!
   isReadOnly: Boolean!
   owner: RepositoryPerson!
+  stars: Float!
   type: String!
   url: String!
 }

--- a/packages/backend/src/lib/backends/file-system.sync.ts
+++ b/packages/backend/src/lib/backends/file-system.sync.ts
@@ -125,8 +125,6 @@ export const getInsight = async (
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     syncedAt: new Date().toISOString(),
-    stars: 0,
-    forks: 0,
     tags: [],
     contributors: [],
     repository: {
@@ -145,8 +143,13 @@ export const getInsight = async (
       isMissing: false,
       isArchived: false,
       // File Insights are always read-only (for now)
-      isReadOnly: true
-    }
+      isReadOnly: true,
+      forks: 0,
+      stars: 0
+    },
+    commentCount: 0,
+    likeCount: 0,
+    viewCount: 0
   };
 
   // Clone the repository locally
@@ -183,7 +186,7 @@ export const getInsight = async (
   }
 
   // Done!
-  logger.debug(JSON.stringify(insight, null, 2));
+  logger.trace(JSON.stringify(insight, null, 2));
 
   return insight;
 };

--- a/packages/backend/src/lib/backends/github.sync.ts
+++ b/packages/backend/src/lib/backends/github.sync.ts
@@ -88,8 +88,6 @@ export async function getInsightFromRepository(owner: string, repo: string): Pro
     createdAt: repository.createdAt!,
     updatedAt: repository.updatedAt!,
     syncedAt: new Date().toISOString(),
-    stars: repository.stargazers!.totalCount,
-    forks: repository.forkCount!,
     tags: repository.repositoryTopics!.edges.map(({ node }: any) => node.topic.name),
     contributors: [],
     repository: {
@@ -108,7 +106,9 @@ export async function getInsightFromRepository(owner: string, repo: string): Pro
       },
       isMissing: false,
       isArchived: repository.isArchived,
-      isReadOnly: repository.isArchived
+      isReadOnly: repository.isArchived,
+      forks: repository.forkCount!,
+      stars: repository.stargazers!.totalCount
     }
   };
 

--- a/packages/backend/src/models/insight.ts
+++ b/packages/backend/src/models/insight.ts
@@ -152,12 +152,6 @@ export class Insight implements IndexedInsight {
   @Field()
   syncedAt!: string;
 
-  @Field()
-  stars!: number;
-
-  @Field()
-  forks!: number;
-
   @Field(() => [String])
   tags!: string[];
 

--- a/packages/backend/src/models/repository.ts
+++ b/packages/backend/src/models/repository.ts
@@ -56,5 +56,11 @@ export class Repository implements IndexedRepository {
   @Field()
   isReadOnly!: boolean;
 
+  @Field()
+  forks!: number;
+
+  @Field()
+  stars!: number;
+
   collaborators?: IndexedInsightUser[];
 }

--- a/packages/backend/src/resolvers/admin.resolver.ts
+++ b/packages/backend/src/resolvers/admin.resolver.ts
@@ -56,7 +56,7 @@ export class AdminResolver {
           return error;
         }
       },
-      { concurrency: 5 }
+      { concurrency: 2 }
     );
 
     return dbInsights.length;

--- a/packages/backend/src/resolvers/insight.resolver.ts
+++ b/packages/backend/src/resolvers/insight.resolver.ts
@@ -25,7 +25,7 @@ import { Service } from 'typedi';
 import { getCollaborators } from '../lib/backends/github';
 import { syncInsight } from '../lib/backends/sync';
 import { getInsight } from '../lib/elasticsearch';
-import { Activity, ActivityType, IndexedActivityDetails } from '../models/activity';
+import { Activity, ActivityType, IndexedInsightActivityDetails } from '../models/activity';
 import { CommentConnection } from '../models/comment';
 import { Context } from '../models/context';
 import { DraftKey } from '../models/draft';
@@ -414,11 +414,9 @@ export class InsightResolver {
       const details = {
         insightId: dbInsightId,
         insightName: insightName
-      } as IndexedActivityDetails;
+      } as IndexedInsightActivityDetails;
 
-      const activityId = await this.activityService.recordActivity(ActivityType.VIEW_INSIGHT, ctx.user!, details);
-      const activity = await this.activityService.getActivity(activityId!);
-      return activity;
+      return this.insightService.viewInsight(details, ctx.user!);
     } catch (error: any) {
       logger.error(error.message);
       throw error;

--- a/packages/frontend/src/pages/search-page/components/search-bar/search-bar.tsx
+++ b/packages/frontend/src/pages/search-page/components/search-bar/search-bar.tsx
@@ -44,7 +44,10 @@ const availableSortFields = [
   { value: 'createdAt', label: 'Created Date' },
   { value: 'updatedAt', label: 'Last Updated Date' },
   { value: 'publishedDate', label: 'Published Date' },
-  { value: 'name', label: 'Name' }
+  { value: 'name', label: 'Name' },
+  { value: 'likeCount', label: 'Likes' },
+  { value: 'viewCount', label: 'Views' },
+  { value: 'commentCount', label: 'Comments' }
 ];
 
 export const SearchBar = (): ReactElement => {

--- a/packages/frontend/src/shared/useInsight.ts
+++ b/packages/frontend/src/shared/useInsight.ts
@@ -52,7 +52,6 @@ const INSIGHT_FRAGMENT = gql`
       }
     }
     tags
-    forks
     viewCount
     likeCount
     commentCount

--- a/packages/frontend/src/shared/useSearch.ts
+++ b/packages/frontend/src/shared/useSearch.ts
@@ -36,7 +36,6 @@ const INSIGHTS_QUERY = gql`
           tags
           likeCount
           commentCount
-          forks
           authors {
             edges {
               node {

--- a/packages/frontend/src/store/search.slice.ts
+++ b/packages/frontend/src/store/search.slice.ts
@@ -81,6 +81,9 @@ export const searchSlice = createSlice({
         case 'createdAt':
         case 'updatedAt':
         case 'publishedDate':
+        case 'commentCount':
+        case 'likeCount':
+        case 'viewCount':
           state.sort.direction = 'desc';
           break;
       }

--- a/packages/models/src/indexed/indexed-insight.ts
+++ b/packages/models/src/indexed/indexed-insight.ts
@@ -50,8 +50,9 @@ export interface IndexedInsight {
   updatedAt: string;
   syncedAt: string;
 
-  stars: number;
-  forks: number;
+  commentCount?: number;
+  likeCount?: number;
+  viewCount?: number;
 
   readme?: IndexedInsightReadme;
 

--- a/packages/models/src/indexed/indexed-repository.ts
+++ b/packages/models/src/indexed/indexed-repository.ts
@@ -30,4 +30,7 @@ export interface IndexedRepository {
   isMissing: boolean;
   isArchived?: boolean;
   isReadOnly: boolean;
+
+  stars: number;
+  forks: number;
 }


### PR DESCRIPTION
Adds three new Insight search options: views, comments, and likes.  A new field for each of these three metrics has been added to Elasticsearch.  Syncing an Insight will recalculate all three; in the meantime each related activity will increment/decrement the corresponding counter.

<img width="353" alt="Screen Shot 2023-02-16 at 4 19 36 PM" src="https://user-images.githubusercontent.com/3084806/219489201-6c5b9c82-1a77-4b51-8a6f-4e9a08a45793.png">
