### PR TITLE
fix: Limit the collaborator fields stored in Elasticsearch

### DIFF
--- a/packages/backend/src/lib/backends/github.sync.ts
+++ b/packages/backend/src/lib/backends/github.sync.ts
@@ -231,7 +231,17 @@ async function getInsightContributors(insight: IndexedInsight, yaml: InsightYaml
 async function getInsightCollaborators(insight: IndexedInsight): Promise<IndexedInsightCollaborator[]> {
   const insightService = Container.get(InsightService);
 
-  return await insightService.getCollaborators(insight as Insight);
+  const collaborators = await insightService.getCollaborators(insight as Insight);
+
+  // Return only the fields we need
+  return collaborators.map(({ permission, user }) => ({
+    permission,
+    user: {
+      userName: user.userName,
+      displayName: user.displayName,
+      email: user.email
+    }
+  }));
 }
 
 /**

--- a/packages/models/src/indexed/indexed-insight-collaborator.ts
+++ b/packages/models/src/indexed/indexed-insight-collaborator.ts
@@ -19,6 +19,6 @@ import type { RepositoryPermission } from '../repository-permission';
 import type { IndexedInsightUser } from './indexed-insight-user';
 
 export interface IndexedInsightCollaborator {
-  user: IndexedInsightUser;
+  user: Pick<IndexedInsightUser, 'userName' | 'displayName' | 'email'>;
   permission: RepositoryPermission;
 }


### PR DESCRIPTION
Avoids issues with invalid users not matching the detected schema

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->
