### PR TITLE
feat: Authors filter shows display names for users, search by display name

### DIFF
--- a/packages/backend/schema.gql
+++ b/packages/backend/schema.gql
@@ -505,6 +505,7 @@ input Sort {
 }
 
 type UniqueValue {
+  label: String
   occurrences: Float!
   value: String!
 }

--- a/packages/backend/src/models/autocomplete.ts
+++ b/packages/backend/src/models/autocomplete.ts
@@ -23,6 +23,9 @@ export class UniqueValue {
 
   @Field()
   occurrences!: number;
+
+  @Field({ nullable: true })
+  label?: string;
 }
 
 @ObjectType()

--- a/packages/backend/src/services/user.service.ts
+++ b/packages/backend/src/services/user.service.ts
@@ -48,6 +48,13 @@ export class UserService {
     return sort(userIds, users, 'userId');
   });
 
+  private usernameLoader: DataLoader<string, User> = new DataLoader(async (usernames) => {
+    logger.trace('usernameLoader');
+    const users = await User.query().whereIn('userName', usernames as string[]);
+
+    return sort(usernames, users, 'userName');
+  });
+
   private commentCountLoader: DataLoader<number, number> = new DataLoader(async (userIds) => {
     logger.trace('commentCountLoader');
 
@@ -82,6 +89,15 @@ export class UserService {
    */
   async getUser(userId: number): Promise<User> {
     return this.userLoader.load(userId);
+  }
+
+  /**
+   * Fetches a User by username.
+   *
+   * @param username User name
+   */
+  async getUserByUserName(username: string): Promise<User> {
+    return this.usernameLoader.load(username);
   }
 
   /**

--- a/packages/frontend/src/pages/search-page/components/filter-sidebar/components/filter-stack/filter-stack.tsx
+++ b/packages/frontend/src/pages/search-page/components/filter-sidebar/components/filter-stack/filter-stack.tsx
@@ -55,17 +55,19 @@ export const FilterStack = ({
   const selectOptions = allFilters
     .filter((filter) => !filterExists(filterKey, filter.value))
     .map((filter) => {
-      return { label: filter.value, value: filter.value };
+      return { label: filter.label ?? filter.value, value: filter.value };
     });
 
   const getLabel = (item: { value: string; label?: string }): string => {
     if (item.label) {
       return item.label;
     }
-    // const filter = allFilters.find((f) => f.value === item.value);
-    // if (filter && filter.label) {
-    //   return filter.label;
-    // }
+
+    const filter = allFilters.find((f) => f.value === item.value);
+    if (filter && filter.label) {
+      return filter.label;
+    }
+
     return item.value;
   };
 

--- a/packages/frontend/src/pages/search-page/components/filter-sidebar/filter-sidebar.tsx
+++ b/packages/frontend/src/pages/search-page/components/filter-sidebar/filter-sidebar.tsx
@@ -48,6 +48,7 @@ const AUTOCOMPLETE_QUERY = gql`
       }
       authors {
         value
+        label
         occurrences
       }
       teams {

--- a/packages/frontend/src/pages/search-page/components/search-bar/search-syntax.tsx
+++ b/packages/frontend/src/pages/search-page/components/search-bar/search-syntax.tsx
@@ -47,7 +47,7 @@ export const SearchSyntax = () => {
           </Tooltip>
         </Box>
       </PopoverTrigger>
-      <PopoverContent zIndex={9000} {...useBreakpointValue({ base: {}, lg: { width: 'auto', maxWidth: '3xl' } })}>
+      <PopoverContent zIndex={9000} {...useBreakpointValue({ base: {}, lg: { width: 'auto', maxWidth: '4xl' } })}>
         <PopoverArrow />
         <PopoverCloseButton />
         <PopoverHeader>
@@ -109,6 +109,8 @@ export const SearchSyntax = () => {
               <Box>
                 <HStack>
                   <Code>author:username</Code>
+                  <Text>/</Text>
+                  <Code whiteSpace="nowrap">author:"Full Name"</Code>
                   <Text>/</Text>
                   <Code>@username</Code>
                 </HStack>

--- a/packages/frontend/src/shared/useSearch.ts
+++ b/packages/frontend/src/shared/useSearch.ts
@@ -65,6 +65,7 @@ const INSIGHTS_QUERY = gql`
       suggestedFilters {
         authors {
           value
+          label
         }
         tags {
           value

--- a/packages/shared/src/search.ts
+++ b/packages/shared/src/search.ts
@@ -151,6 +151,36 @@ export class SearchTerm implements SearchClause {
       return {};
     }
 
+    if (this.key === 'author') {
+      // Special case for supporting either username or display name
+      return {
+        bool: {
+          filter: [
+            {
+              bool: {
+                should: [
+                  {
+                    term: {
+                      'contributors.userName.keyword': {
+                        value: this.value
+                      }
+                    }
+                  },
+                  {
+                    term: {
+                      'contributors.displayName.keyword': {
+                        value: this.value
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      };
+    }
+
     return {
       bool: {
         filter: [
@@ -169,7 +199,7 @@ export class SearchTerm implements SearchClause {
   toString(): string {
     switch (this.key) {
       case 'author':
-        return `@${this.value}`;
+        return this.value.includes(' ') ? `author:"${this.value}"` : `@${this.value}`;
       case 'tag':
         return `#${this.value}`;
       default:

--- a/packages/shared/test/search.test.ts
+++ b/packages/shared/test/search.test.ts
@@ -342,7 +342,14 @@ describe('search', () => {
         bool: {
           filter: [
             { term: { 'tags.keyword': { value: 'demo' } } },
-            { term: { 'contributors.userName.keyword': { value: 'username' } } }
+            {
+              bool: {
+                should: [
+                  { term: { 'contributors.userName.keyword': { value: 'username' } } },
+                  { term: { 'contributors.displayName.keyword': { value: 'username' } } }
+                ]
+              }
+            }
           ],
           should: [
             {
@@ -394,7 +401,16 @@ describe('search', () => {
       const es = parseToElasticsearch('author:username');
       expect(es).toMatchObject({
         bool: {
-          filter: [{ term: { 'contributors.userName.keyword': { value: 'username' } } }]
+          filter: [
+            {
+              bool: {
+                should: [
+                  { term: { 'contributors.userName.keyword': { value: 'username' } } },
+                  { term: { 'contributors.displayName.keyword': { value: 'username' } } }
+                ]
+              }
+            }
+          ]
         }
       });
     });
@@ -450,6 +466,11 @@ describe('search', () => {
       const clauses: any[] = parseSearchQuery('updatedDate:>=2020-03-01 updatedDate:<=2020-10-01');
       const query = toSearchQuery(clauses);
       expect(query).toBe('updatedDate:>=2020-03-01 updatedDate:<=2020-10-01');
+    });
+    test('author full name', () => {
+      const clauses: any[] = parseSearchQuery('author:"John Doe"');
+      const query = toSearchQuery(clauses);
+      expect(query).toBe('author:"John Doe"');
     });
   });
 });


### PR DESCRIPTION
Two changes related to user display names:
* Authors filter shows display names (if available) instead of usernames.  When selected, the `@username` filter is added as before
* Filtering by display name is now possible using new `author:"Full Name"` syntax.
 
![Screenshot 2023-04-06 at 1 41 06 PM](https://user-images.githubusercontent.com/3084806/230461996-39a767e6-b2e1-478d-a5cd-e17e53e27e2c.png)
