### PR TITLE
feat: Sync all collaborators to allow teams to view unlisted Insights

### DIFF
--- a/packages/backend/src/lib/backends/base.sync.ts
+++ b/packages/backend/src/lib/backends/base.sync.ts
@@ -86,7 +86,7 @@ export abstract class BaseSync {
         refresh
       });
 
-      logger.trace(JSON.stringify(result));
+      //logger.trace(JSON.stringify(result));
       logger.info(`Successfully published ${documentType}: ${insight.fullName}`);
     } catch (error: any) {
       logger.error(`Error publishing ${documentType} to Elasticsearch`);

--- a/packages/backend/src/lib/backends/github.sync.ts
+++ b/packages/backend/src/lib/backends/github.sync.ts
@@ -231,7 +231,9 @@ async function getInsightContributors(insight: IndexedInsight, yaml: InsightYaml
 async function getInsightCollaborators(insight: IndexedInsight): Promise<IndexedInsightCollaborator[]> {
   const insightService = Container.get(InsightService);
 
-  const collaborators = await insightService.getCollaborators(insight as Insight);
+  // Get all collaborators for the insight -- this includes Orgs, Teams and Users
+  // These are stored in Elasticsearch only for the purpose of searching for unlisted Insights
+  const collaborators = await insightService.getCollaborators(insight as Insight, 'ALL');
 
   // Return only the fields we need
   return collaborators.map(({ permission, user }) => ({

--- a/packages/backend/src/models/backends/github.ts
+++ b/packages/backend/src/models/backends/github.ts
@@ -105,6 +105,8 @@ export type GitHubRepositoryHistoryEdge = { node: GitHubCommit };
 
 export type GitHubRepositoryPermission = 'ADMIN' | 'MAINTAIN' | 'READ' | 'TRIAGE' | 'WRITE' | 'NONE';
 
+export type GitHubCollaboratorAffiliation = 'OUTSIDE' | 'DIRECT' | 'ALL';
+
 export interface GitHubOrganization {
   id: string;
   name: string;

--- a/packages/backend/src/resolvers/insight.resolver.ts
+++ b/packages/backend/src/resolvers/insight.resolver.ts
@@ -179,7 +179,7 @@ export class InsightResolver {
 
   @FieldResolver()
   async collaborators(@Root() insight: Insight): Promise<UserPermissionConnection> {
-    const users = await this.insightService.getCollaborators(insight);
+    const users = await this.insightService.getCollaborators(insight, 'DIRECT');
 
     return {
       edges: users.map(({ user, permission }, i) => ({

--- a/packages/backend/src/services/insight.service.ts
+++ b/packages/backend/src/services/insight.service.ts
@@ -54,7 +54,7 @@ import {
 } from '../lib/elasticsearch';
 import { GitInstance } from '../lib/git-instance';
 import { Activity, ActivityType, IndexedInsightActivityDetails } from '../models/activity';
-import { GitHubRepository, RepositoryVisibility } from '../models/backends/github';
+import { GitHubCollaboratorAffiliation, GitHubRepository, RepositoryVisibility } from '../models/backends/github';
 import { Comment } from '../models/comment';
 import { Draft } from '../models/draft';
 import { DbInsight, Insight, ValidateInsightName } from '../models/insight';
@@ -727,15 +727,26 @@ export class InsightService {
   /**
    * Gets Collaborators for an Insight
    */
-  async getCollaborators(insight: Insight): Promise<IndexedInsightCollaborator[]> {
+  async getCollaborators(
+    insight: Insight,
+    affiliation: GitHubCollaboratorAffiliation = 'DIRECT'
+  ): Promise<IndexedInsightCollaborator[]> {
     if (insight.repository.type === RepositoryType.FILE) {
       return [];
     }
 
-    const gitHubCollaborators = await getCollaborators(insight.repository.owner.login, insight.repository.externalName);
+    const gitHubCollaborators = await getCollaborators(
+      insight.repository.owner.login,
+      insight.repository.externalName,
+      affiliation
+    );
     if (gitHubCollaborators == null || gitHubCollaborators.length === 0) {
       return [];
     }
+
+    gitHubCollaborators.forEach((collaborator: any) => {
+      logger.debug(`Collaborator: ${JSON.stringify(collaborator, null, 2)}`);
+    });
 
     return await Promise.all(
       gitHubCollaborators

--- a/packages/frontend/src/components/insight-collaborators-modal/insight-collaborators-modal.tsx
+++ b/packages/frontend/src/components/insight-collaborators-modal/insight-collaborators-modal.tsx
@@ -44,6 +44,7 @@ import { iconFactoryAs } from '../../shared/icon-factory';
 import type { RootState } from '../../store/store';
 import { Alert } from '../alert/alert';
 import { DeleteIconButton } from '../delete-icon-button/delete-icon-button';
+import { ExternalLink } from '../external-link/external-link';
 import { Link as RouterLink } from '../link/link';
 
 import { PermissionMenu } from './permission-menu';
@@ -51,6 +52,9 @@ import { PermissionMenu } from './permission-menu';
 const COLLABORATORS_FRAGMENT = gql`
   fragment CollaboratorFields on Insight {
     id
+    repository {
+      url
+    }
     collaborators {
       edges {
         permission
@@ -127,7 +131,8 @@ const InsightCollaboratorsModalInternal = ({ insightId }) => {
     variables: { id: insightId }
   });
 
-  const edges = data?.insight.collaborators?.edges;
+  const insight = data?.insight;
+  const edges = insight?.collaborators?.edges;
 
   const [{ data: usersData }] = useQuery({
     query: USERS_QUERY
@@ -262,7 +267,17 @@ const InsightCollaboratorsModalInternal = ({ insightId }) => {
       <Divider />
 
       <Text fontSize="xs">
-        Collaborators with access through GitHub Teams or Organization permissions are not shown.
+        Collaborators with access through GitHub Teams or Organization permissions are not shown. Manage GitHub Teams
+        permissions for the repository{' '}
+        <ExternalLink
+          href={insight?.repository.url + '/settings/access'}
+          isExternal={true}
+          showIcon={true}
+          display="inline-block"
+        >
+          here
+        </ExternalLink>
+        .
       </Text>
     </VStack>
   );


### PR DESCRIPTION
Currently, IEX only manages direct collaborators, e.g. users added directly to an Insight repository.  Teams and organizational users don't appear in IEX, and cannot be managed by the UI--they must be managed directly in GitHub.

However, this meant that Unlisted Insights don't appear unless you are a direct collaborator on an Insight.  This is not ideal, so this PR makes a change to the Insight sync process to include ALL collaborators (with higher than READ permissions).  These collaborators are synced to Elasticsearch and will be used to determine if an unlisted Insight can be shown.

This PR does not change the Collaborators UI within IEX--it continues to show and manage direct collaborators only.  A direct link has been added to open the Insight's repository access page in GitHub, however.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->
