### PR TITLE
fix: Attachment-related issues

### DIFF
--- a/packages/backend/src/resolvers/attachment.resolver.ts
+++ b/packages/backend/src/resolvers/attachment.resolver.ts
@@ -59,10 +59,10 @@ export class AttachmentResolver {
       const mimeType = await getTypeAsync({ fileName: file.filename, stream });
 
       return {
-        name: file.filename,
-        path: file.filename,
+        ...attachment,
         mimeType,
-        ...attachment
+        name: attachment.name ?? file.filename,
+        path: attachment.path ?? file.filename
       };
     } catch (error: any) {
       logger.error(error);

--- a/packages/frontend/src/pages/settings-page/components/profile-settings/profile-settings.tsx
+++ b/packages/frontend/src/pages/settings-page/components/profile-settings/profile-settings.tsx
@@ -76,6 +76,7 @@ const AUTOCOMPLETE_QUERY = gql`
 const AVATAR_UPLOAD_MUTATION = gql`
   mutation AvatarUpload($size: Float!, $file: Upload!) {
     uploadUserAvatar(size: $size, file: $file) {
+      avatar
       avatarUrl
     }
   }


### PR DESCRIPTION
Fixes two issues with attachments:
- uploading files to an Insight was broken by the switch to ES2022
- newly uploaded avatars were not saving correctly