### PR TITLE
fix: Prevent continuously dispatching search/setSearchResults action

### DIFF
--- a/packages/frontend/src/pages/search-page/search-page.tsx
+++ b/packages/frontend/src/pages/search-page/search-page.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Box, Stack, VStack } from '@chakra-ui/react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { Helmet } from 'react-helmet';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
@@ -49,9 +49,11 @@ export const SearchPage = () => {
     useNewSearch
   });
 
-  const insightResults = data.insights.results.map(({ insight }) => {
-    return { id: insight.id, name: insight.name, fullName: insight.fullName, itemType: insight.itemType };
-  });
+  const insightResults = useMemo(() => {
+    return data.insights.results.map(({ insight }) => {
+      return { id: insight.id, name: insight.name, fullName: insight.fullName, itemType: insight.itemType };
+    });
+  }, [data.insights.results]);
 
   useEffect(() => {
     if (!initialized.current) {


### PR DESCRIPTION
Previously, the `search/setSearchResults` Redux action was being continuously dispatched with the same results, forever.

Added `useMemo` to reuse the same results object, preventing the `useEffect` from triggering the dispatch.

Before:
![Screenshot 2024-01-19 at 9 06 20 AM](https://github.com/ExpediaGroup/insights-explorer/assets/3084806/caa01ffd-9642-4cb9-81bd-4c25976cdd0d)
