### PR TITLE
feat: Insight Sidebar improvements, including file type icons and auto-hiding sections

### DIFF
--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-sidebar/insight-sidebar.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-sidebar/insight-sidebar.tsx
@@ -44,6 +44,7 @@ import { UserTag } from '../../../../../../components/user-tag/user-tag';
 import type { Insight } from '../../../../../../models/generated/graphql';
 import { formatDateIntl, formatRelativeIntl } from '../../../../../../shared/date-utils';
 import { iconFactory } from '../../../../../../shared/icon-factory';
+import { fileIconFactoryAs } from '../../../../../../shared/file-icon-factory';
 import { groupInsightLinks } from '../../../../../../shared/insight-utils';
 import { GitHubButton } from '../github-button/github-button';
 import { ShareMenu } from '../share-menu/share-menu';
@@ -186,6 +187,16 @@ export const InsightSidebar = ({ insight, ...props }: { insight: Insight } & Box
               return (
                 <Link to={`/${insight.itemType}/${insight.fullName}/files/${file.path}`} key={file.id}>
                   <Tag bg={fileBgColor} rounded="full">
+                    {fileIconFactoryAs(
+                      {
+                        mimeType: file.mimeType,
+                        fileName: file.name,
+                        isFolder: false,
+                        isOpen: false,
+                        isSelected: false
+                      },
+                      { fontSize: '1rem', mr: '0.5rem' }
+                    )}
                     <TagLabel>{file.path}</TagLabel>
                   </Tag>
                 </Link>

--- a/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-sidebar/insight-sidebar.tsx
+++ b/packages/frontend/src/pages/insight-page/components/insight-viewer/components/insight-sidebar/insight-sidebar.tsx
@@ -128,20 +128,28 @@ export const InsightSidebar = ({ insight, ...props }: { insight: Insight } & Box
         <ShareMenu insight={insight} />
       </HStack>
 
-      <StackDivider borderColor="snowstorm.100" borderTopWidth="1px" />
+      {insight.metadata?.team && (
+        <>
+          <StackDivider borderColor="snowstorm.100" borderTopWidth="1px" />
 
-      <SidebarStack heading="Team" tooltip="Team which owns this Insight">
-        <TeamTag team={insight.metadata?.team ?? 'Unknown'} size="lg" />
-      </SidebarStack>
+          <SidebarStack heading="Team" tooltip="Team which owns this Insight">
+            <TeamTag team={insight.metadata?.team} size="lg" />
+          </SidebarStack>
+        </>
+      )}
 
-      <StackDivider borderColor="snowstorm.100" borderTopWidth="1px" />
+      {authors && authors.length > 0 && (
+        <>
+          <StackDivider borderColor="snowstorm.100" borderTopWidth="1px" />
+          <SidebarHeading>Authors</SidebarHeading>
+          <Stack spacing="0.25rem">
+            {authors.map((author) => (
+              <UserTag key={author.userName} user={author} permission={author.permission} size="lg" width="100%" />
+            ))}
+          </Stack>
+        </>
+      )}
 
-      <SidebarHeading>Authors</SidebarHeading>
-      <Stack spacing="0.25rem">
-        {authors.map((author) => (
-          <UserTag key={author.userName} user={author} permission={author.permission} size="lg" width="100%" />
-        ))}
-      </Stack>
       {insight.tags?.length > 0 && (
         <>
           <StackDivider borderColor="snowstorm.100" borderTopWidth="1px" />

--- a/packages/frontend/src/theme.ts
+++ b/packages/frontend/src/theme.ts
@@ -271,6 +271,13 @@ export const IexTheme = extendTheme({
           _hover: {
             bg: 'polar.500'
           }
+        },
+        snowstorm: {
+          bg: 'snowstorm.300',
+          color: 'polar.600',
+          _hover: {
+            bg: 'snowstorm.200'
+          }
         }
       }
     },


### PR DESCRIPTION
Improvements to the Insight Sidebar:
- Showing file type icons like in the editor
![Screenshot 2024-01-29 at 12 02 12 PM](https://github.com/ExpediaGroup/insights-explorer/assets/3084806/ab210b9f-a62b-41a3-9331-ac935a95ca03) 
- Automatically removing empty sections, e.g. no Authors, no Team
![Screenshot 2024-01-29 at 12 29 48 PM](https://github.com/ExpediaGroup/insights-explorer/assets/3084806/db7d9a08-efb0-4bed-b847-17e5fb2e1e61)
- Moved Files up, and collapse by default to only show 5
