### PR TITLE
fix: Avoid indexing large files

### DIFF
--- a/packages/backend/src/lib/backends/github.sync.ts
+++ b/packages/backend/src/lib/backends/github.sync.ts
@@ -482,7 +482,12 @@ const syncFiles = async (
       };
 
       // Include the contents of text-based files
-      if (INDEXABLE_MIME_TYPES.has(file.mimeType) || file.mimeType.startsWith('text/')) {
+      if (
+        INDEXABLE_MIME_TYPES.has(file.mimeType) ||
+        (file.mimeType.startsWith('text/') &&
+          // Ensure the file is less than 1MB
+          file.size < 1024 * 1024)
+      ) {
         file.contents = contents?.toString('utf8');
       }
 


### PR DESCRIPTION
Files like `text/csv` pass the MIME type check, but might be way too large for Elasticsearch.  